### PR TITLE
Fix 44.1kHz issue

### DIFF
--- a/components/dsp_processor/dsp_processor.c
+++ b/components/dsp_processor/dsp_processor.c
@@ -37,10 +37,11 @@ static uint32_t currentChunkDurationMs = 0;
 
 static ptype_t bq[8];
 
+static double dynamic_vol = 1.0;
+
 int
 dsp_processor (char *audio, size_t chunk_size, dspFlows_t dspFlow)
 {
-  double dynamic_vol = 1.0;
   int16_t len = chunk_size / 4;
   int16_t valint;
   uint16_t i;
@@ -58,6 +59,17 @@ dsp_processor (char *audio, size_t chunk_size, dspFlows_t dspFlow)
     {
     case dspfStereo:
       {
+          //set volume
+          if (dynamic_vol != 1.0)
+            {
+              for (i = 0; i < len; i++)
+              {
+                audio_tmp[i] = ((uint32_t) (dynamic_vol
+                               * ((float)((int16_t)((audio_tmp[i] & 0xFFFF0000) >> 16)))) << 16)
+                               + (uint32_t) (dynamic_vol
+                               * ((float)((int16_t)(audio_tmp[i] & 0xFFFF))));
+              }
+            }
       }
       break;
 
@@ -372,6 +384,16 @@ dsp_set_xoverfreq (uint8_t freqh, uint8_t freql, uint32_t samplerate)
         default:
           break;
         }
+    }
+}
+
+void
+dsp_set_vol (double volume)
+{
+  if (volume >= 0 && volume <= 1.0)
+    {
+      ESP_LOGI (TAG, "Set volume to %f", volume);
+      dynamic_vol = volume;
     }
 }
 #endif

--- a/components/dsp_processor/include/dsp_processor.h
+++ b/components/dsp_processor/include/dsp_processor.h
@@ -42,5 +42,6 @@ typedef struct pnode {
 void dsp_setup_flow(double freq, uint32_t samplerate, uint32_t chunkDurationMs);
 int dsp_processor(char *audio, size_t chunk_size, dspFlows_t dspFlow);
 void dsp_set_xoverfreq(uint8_t, uint8_t, uint32_t);
+void dsp_set_vol(double volume);
 
 #endif /* _DSP_PROCESSOR_H_  */

--- a/components/dsp_processor/include/dsp_processor.h
+++ b/components/dsp_processor/include/dsp_processor.h
@@ -39,7 +39,7 @@ typedef struct pnode {
   struct pnode *next;
 } pnode_t;
 
-void dsp_setup_flow(double freq, uint32_t samplerate, uint32_t chunkDurationMs);
+void dsp_setup_flow(double freq, uint32_t samplerate, float chunkDurationMs);
 int dsp_processor(char *audio, size_t chunk_size, dspFlows_t dspFlow);
 void dsp_set_xoverfreq(uint8_t, uint8_t, uint32_t);
 void dsp_set_vol(double volume);

--- a/components/lightsnapcast/include/player.h
+++ b/components/lightsnapcast/include/player.h
@@ -35,7 +35,7 @@ typedef enum codec_type_e { NONE = 0, PCM, FLAC, OGG, OPUS } codec_type_t;
 
 typedef struct snapcastSetting_s {
   uint32_t buf_ms;
-  uint32_t chkDur_ms;
+  float chkDur_ms;
   int32_t cDacLat_ms;
 
   codec_type_t codec;

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -19,16 +19,10 @@ menu "Snapcast Configuration"
         depends on !SNAPSERVER_USE_MDNS
         help
             Port of the snapserver to connect to.
-            
-    config SNAPCLIENT_BUFF_LEN
-        int "snapcast protocol buffer len"
-        default 4000
-        help
-            Size of the snapclient protocol messages buffer (in bytes).
 
     config SNAPCLIENT_NAME
         string "snapclient name"
-        default "esp-snapclient"
+        default "ESP32-Caster"
         help
             Name of the client to register the snapserver.
 

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -33,6 +33,22 @@ menu "Snapcast Configuration"
         help
             Use software volume mixer instead of hardware mixer.
 
+    choice SNAPCLIENT_DSP_FLOW
+        prompt "DSP flow"
+        default SNAPCLIENT_DSP_FLOW_STEREO
+        help
+            Select the DSP flow to use.
+
+        config SNAPCLIENT_DSP_FLOW_STEREO
+            bool "Stereo flow"
+
+        config SNAPCLIENT_DSP_FLOW_BASSBOOST
+            bool "Bassboost flow"
+
+        config SNAPCLIENT_DSP_FLOW_BIAMP
+            bool "Bi-Amp flow"
+    endchoice
+
 endmenu
 
 menu "SNTP Configuration"

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -31,6 +31,14 @@ menu "Snapcast Configuration"
         default "esp-snapclient"
         help
             Name of the client to register the snapserver.
+
+    config SNAPCLIENT_USE_SOFT_VOL
+        bool "Use software volume"
+        default false
+        depends on USE_DSP_PROCESSOR
+        help
+            Use software volume mixer instead of hardware mixer.
+
 endmenu
 
 menu "SNTP Configuration"

--- a/main/main.c
+++ b/main/main.c
@@ -1411,9 +1411,9 @@ static void http_get_task(void *pvParameters) {
                                     double dynamic_vol = ((double)scSet.volume/100 / (20 - flow_drain_counter));
                                     if (flow_drain_counter == 0) {
 #if SNAPCAST_USE_SOFT_VOL
-                                        dsp_set_vol(0.0);
+                                        dynamic_vol = 0;
 #else
-                                        dsp_set_vol(1.0);
+                                        dynamic_vol = 1;
 #endif
                                         audio_hal_set_mute(board_handle->audio_hal,
                                              server_settings_message.muted);
@@ -1463,9 +1463,9 @@ static void http_get_task(void *pvParameters) {
                                     double dynamic_vol = ((double)scSet.volume/100 / (20 - flow_drain_counter));
                                     if (flow_drain_counter == 0) {
 #if SNAPCAST_USE_SOFT_VOL
-                                        dsp_set_vol(0.0);
+                                        dynamic_vol = 0;
 #else
-                                        dsp_set_vol(1.0);
+                                        dynamic_vol = 1;
 #endif
                                         audio_hal_set_mute(board_handle->audio_hal,
                                              server_settings_message.muted);

--- a/main/main.c
+++ b/main/main.c
@@ -103,6 +103,7 @@ static audio_board_handle_t board_handle = NULL;
 #endif
 #define SNAPCAST_BUFF_LEN CONFIG_SNAPCLIENT_BUFF_LEN
 #define SNAPCAST_CLIENT_NAME CONFIG_SNAPCLIENT_NAME
+#define SNAPCAST_USE_SOFT_VOL CONFIG_SNAPCLIENT_USE_SOFT_VOL
 
 /* Logging tag */
 static const char *TAG = "SC";
@@ -785,6 +786,7 @@ static void http_get_task(void *pvParameters) {
     uint32_t typedMsgLen = 0;
     uint32_t offset = 0;
     uint32_t tmpData = 0;
+    int flow_drain_counter = 0;
 
 #define BASE_MESSAGE_STATE 0
 #define TYPED_MESSAGE_STATE 1
@@ -1405,6 +1407,20 @@ static void http_get_task(void *pvParameters) {
                                 endTime = esp_timer_get_time();
 
 #if CONFIG_USE_DSP_PROCESSOR
+                                if (flow_drain_counter > 0) {
+                                    flow_drain_counter--;
+                                    double dynamic_vol = ((double)scSet.volume/100 / (20 - flow_drain_counter));
+                                    if (flow_drain_counter == 0) {
+#if SNAPCAST_USE_SOFT_VOL
+                                        dsp_set_vol(0.0);
+#else
+                                        dsp_set_vol(1.0);
+#endif
+                                        audio_hal_set_mute(board_handle->audio_hal,
+                                             server_settings_message.muted);
+                                    }
+                                    dsp_set_vol(dynamic_vol);
+                                }
                                 dsp_setup_flow(500, scSet.sr, scSet.chkDur_ms);
                                 dsp_processor(pcmData->fragment->payload,
                                               pcmData->fragment->size, dspFlow);
@@ -1443,6 +1459,20 @@ static void http_get_task(void *pvParameters) {
                               }
 
 #if CONFIG_USE_DSP_PROCESSOR
+                                if (flow_drain_counter > 0) {
+                                    flow_drain_counter--;
+                                    double dynamic_vol = ((double)scSet.volume/100 / (20 - flow_drain_counter));
+                                    if (flow_drain_counter == 0) {
+#if SNAPCAST_USE_SOFT_VOL
+                                        dsp_set_vol(0.0);
+#else
+                                        dsp_set_vol(1.0);
+#endif
+                                        audio_hal_set_mute(board_handle->audio_hal,
+                                             server_settings_message.muted);
+                                    }
+                                    dsp_set_vol(dynamic_vol);
+                                }
                               dsp_setup_flow(500, scSet.sr, scSet.chkDur_ms);
                               dsp_processor(pcmData->fragment->payload,
                                             pcmData->fragment->size, dspFlow);
@@ -1982,12 +2012,32 @@ static void http_get_task(void *pvParameters) {
                         // Volume setting using ADF HAL
                         // abstraction
                         if (scSet.muted != server_settings_message.muted) {
+#if CONFIG_USE_DSP_PROCESSOR
+                          if (server_settings_message.muted) {
+                            flow_drain_counter = 20;
+                          }
+                          else {
+                              flow_drain_counter = 0;
+                              audio_hal_set_mute(board_handle->audio_hal,
+                                             server_settings_message.muted);
+#if SNAPCAST_USE_SOFT_VOL
+                              dsp_set_vol((double)server_settings_message.volume/100);
+#else
+                              dsp_set_vol(1.0);
+#endif
+                          }
+#else
                           audio_hal_set_mute(board_handle->audio_hal,
                                              server_settings_message.muted);
+#endif
                         }
                         if (scSet.volume != server_settings_message.volume) {
+#if SNAPCAST_USE_SOFT_VOL
+                          dsp_set_vol((double)server_settings_message.volume/100);
+#else
                           audio_hal_set_volume(board_handle->audio_hal,
                                                server_settings_message.volume);
+#endif
                         }
 
                         scSet.cDacLat_ms = server_settings_message.latency;

--- a/main/main.c
+++ b/main/main.c
@@ -101,7 +101,6 @@ static audio_board_handle_t board_handle = NULL;
 #define SNAPCAST_SERVER_HOST CONFIG_SNAPSERVER_HOST
 #define SNAPCAST_SERVER_PORT CONFIG_SNAPSERVER_PORT
 #endif
-#define SNAPCAST_BUFF_LEN CONFIG_SNAPCLIENT_BUFF_LEN
 #define SNAPCAST_CLIENT_NAME CONFIG_SNAPCLIENT_NAME
 #define SNAPCAST_USE_SOFT_VOL CONFIG_SNAPCLIENT_USE_SOFT_VOL
 
@@ -723,7 +722,7 @@ static void http_get_task(void *pvParameters) {
 
     // init hello message
     hello_message.mac = mac_address;
-    hello_message.hostname = "ESP32-Caster";
+    hello_message.hostname = SNAPCAST_CLIENT_NAME;
     hello_message.version = (char *)VERSION_STRING;
     hello_message.client_name = "libsnapcast";
     hello_message.os = "esp32";

--- a/main/main.c
+++ b/main/main.c
@@ -113,7 +113,15 @@ extern char mac_address[18];
 SemaphoreHandle_t timeSyncSemaphoreHandle = NULL;
 
 #if CONFIG_USE_DSP_PROCESSOR
-uint8_t dspFlow = dspfStereo;  // dspfBiamp; // dspfStereo; // dspfBassBoost;
+#if CONFIG_SNAPCLIENT_DSP_FLOW_STEREO
+dspFlows_t dspFlow = dspfStereo;  // dspfBiamp; // dspfStereo; // dspfBassBoost;
+#endif
+#if CONFIG_SNAPCLIENT_DSP_FLOW_BASSBOOST
+dspFlows_t dspFlow = dspfBassBoost;
+#endif
+#if CONFIG_SNAPCLIENT_DSP_FLOW_BIAMP
+dspFlows_t dspFlow = dspfBiamp;
+#endif
 #endif
 
 typedef struct flacData_s {

--- a/main/main.c
+++ b/main/main.c
@@ -500,7 +500,7 @@ void flac_task(void *pvParameters) {
 
         size_t decodedSize = pcmData->totalSize;  // pFlacData->bytes;
         scSet->chkDur_ms = (1000UL * decodedSize) /
-                           (uint32_t)(scSet->ch * (scSet->bits / 8)) /
+                           (float)(scSet->ch * (scSet->bits / 8)) /
                            scSet->sr;
         if (player_send_snapcast_setting(scSet) != pdPASS) {
           ESP_LOGE(TAG,
@@ -1396,7 +1396,7 @@ static void http_get_task(void *pvParameters) {
                                     pcmData->totalSize;  // pFlacData->bytes;
                                 scSet.chkDur_ms =
                                     (1000UL * decodedSize) /
-                                    (uint32_t)(scSet.ch * (scSet.bits / 8)) /
+                                    (float)(scSet.ch * (scSet.bits / 8)) /
                                     scSet.sr;
                                 if (player_send_snapcast_setting(&scSet) !=
                                     pdPASS) {
@@ -1452,7 +1452,7 @@ static void http_get_task(void *pvParameters) {
 
                               scSet.chkDur_ms =
                                   (1000UL * decodedSize) /
-                                  (uint32_t)(scSet.ch * (scSet.bits / 8)) /
+                                  (float)(scSet.ch * (scSet.bits / 8)) /
                                   scSet.sr;
                               if (player_send_snapcast_setting(&scSet) !=
                                   pdPASS) {


### PR DESCRIPTION
This is a first attempt to fix #15

I changed `chkDur_ms` to float and in the player task also `chkDur_us`, `age` , and `outputBufferDacTime`. I am not sure if float is enough or if double should be used. `avg` and the median filters still use int64_t and the timer is in µs (`tg0_timer1_start((uint64_t)(-age+0.5f));  // timer with 1µs ticks`). Not sure if this is a problem.

I have tested it with 48kHz and 44.1kHz. For 48kHz, I don't hear any difference and for 44.1kHz I have some skippings, but I have them on a linux client as well. Maybe @velaar or @gh7531 could test it?
Also looking at a scope while playing a sine wave signal could help as well.