### PR TITLE
Fix wifi init after erased flash

### DIFF
--- a/components/wifi_interface/wifi_interface.c
+++ b/components/wifi_interface/wifi_interface.c
@@ -245,10 +245,10 @@ void wifi_init(void) {
               .pmf_cfg = {.capable = true, .required = false},
           },
   };
-  ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config));
 
   /* Start Wi-Fi station */
   ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+  ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config));
   ESP_ERROR_CHECK(esp_wifi_start());
 
   ESP_LOGI(TAG, "wifi_init_sta finished.");


### PR DESCRIPTION
After flash is erased `wifi_init()` will lead to core panic if provisioning is not used, because the mode is not set correctly. Moving `set config` after `set mode` works for me.