### PR TITLE
Modify MedianFilter to work with non-full buffer

### DIFF
--- a/components/libmedian/include/MedianFilter.h
+++ b/components/libmedian/include/MedianFilter.h
@@ -37,7 +37,8 @@ typedef struct {
 int MEDIANFILTER_Init(sMedianFilter_t *medianFilter);
 int64_t MEDIANFILTER_Insert(sMedianFilter_t *medianFilter, int64_t sample);
 int64_t MEDIANFILTER_get_median(sMedianFilter_t *medianFilter, uint32_t n);
-uint32_t MEDIANFILTER_isFull(sMedianFilter_t *medianFilter);
+uint32_t MEDIANFILTER_isFull(sMedianFilter_t *medianFilter, uint32_t n);
+
 
 #ifdef __cplusplus
 }

--- a/components/lightsnapcast/include/player.h
+++ b/components/lightsnapcast/include/player.h
@@ -14,6 +14,7 @@
 #define CHNK_CTRL_CNT 2
 
 #define LATENCY_MEDIAN_FILTER_LEN 199
+#define LATENCY_MEDIAN_FILTER_FULL 19
 
 // set to 0 if you do not wish to be the median an average around actual
 // median average will be (LATENCY_MEDIAN_FILTER_LEN /

--- a/components/lightsnapcast/player.c
+++ b/components/lightsnapcast/player.c
@@ -365,7 +365,7 @@ int32_t player_latency_insert(int64_t newValue) {
 
   medianValue = MEDIANFILTER_Insert(&latencyMedianFilter, newValue);
   if (xSemaphoreTake(latencyBufSemaphoreHandle, pdMS_TO_TICKS(0)) == pdTRUE) {
-    if (MEDIANFILTER_isFull(&latencyMedianFilter)) {
+    if (MEDIANFILTER_isFull(&latencyMedianFilter, LATENCY_MEDIAN_FILTER_FULL)) {
       latencyBuffFull = true;
 
       //      ESP_LOGI(TAG, "(full) latency median: %lldus", medianValue);
@@ -1417,7 +1417,7 @@ static void player_task(void *pvParameters) {
 
         // resync hard if we are getting very late / early.
         // rest gets tuned in through apll speed control
-        if ((msgWaiting == 0) || (MEDIANFILTER_isFull(&shortMedianFilter) &&
+        if ((msgWaiting == 0) || (MEDIANFILTER_isFull(&shortMedianFilter,0) &&
                                   (abs(shortMedian) > hardResyncThreshold)))
         //        if (msgWaiting == 0)
         {
@@ -1467,7 +1467,7 @@ static void player_task(void *pvParameters) {
 
 #if USE_SAMPLE_INSERTION  // WIP: insert samples to adjust sync
         if ((enableControlLoop == true) &&
-            (MEDIANFILTER_isFull(&shortMedianFilter))) {
+            (MEDIANFILTER_isFull(&shortMedianFilter,0))) {
           if (avg < -miniOffset) {  // we are early
             dir = -1;
             dir_insert_sample = -1;
@@ -1478,7 +1478,7 @@ static void player_task(void *pvParameters) {
         }
 #else  // use APLL to adjust sync
         if ((enableControlLoop == true) &&
-            (MEDIANFILTER_isFull(&shortMedianFilter))) {
+            (MEDIANFILTER_isFull(&shortMedianFilter,0))) {
           if ((shortMedian < -shortOffset) && (miniMedian < -miniOffset) &&
               (avg < -miniOffset)) {  // we are early
             dir = -1;

--- a/main/main.c
+++ b/main/main.c
@@ -778,21 +778,6 @@ static void http_get_task(void *pvParameters) {
     timeout = FAST_SYNC_LATENCY_BUF;
 
     esp_timer_stop(timeSyncMessageTimer);
-    if (received_header == true) {
-      if (!esp_timer_is_active(timeSyncMessageTimer)) {
-        esp_timer_start_periodic(timeSyncMessageTimer, timeout);
-      }
-
-      bool is_full = false;
-      latency_buffer_full(&is_full, portMAX_DELAY);
-      if ((is_full == true) && (timeout < NORMAL_SYNC_LATENCY_BUF)) {
-        if (esp_timer_is_active(timeSyncMessageTimer)) {
-          esp_timer_stop(timeSyncMessageTimer);
-        }
-
-        esp_timer_start_periodic(timeSyncMessageTimer, timeout);
-      }
-    }
 
     if (opusDecoder != NULL) {
       opus_decoder_destroy(opusDecoder);
@@ -2210,18 +2195,6 @@ static void http_get_task(void *pvParameters) {
                           esp_timer_start_periodic(timeSyncMessageTimer,
                                                    timeout);
                         }
-
-                        bool is_full = false;
-                        latency_buffer_full(&is_full, portMAX_DELAY);
-                        if ((is_full == true) &&
-                            (timeout < NORMAL_SYNC_LATENCY_BUF)) {
-                          if (esp_timer_is_active(timeSyncMessageTimer)) {
-                            esp_timer_stop(timeSyncMessageTimer);
-                          }
-
-                          esp_timer_start_periodic(timeSyncMessageTimer,
-                                                   timeout);
-                        }
                       }
 
                       break;
@@ -2636,18 +2609,6 @@ static void http_get_task(void *pvParameters) {
                               esp_timer_start_periodic(timeSyncMessageTimer,
                                                        timeout);
                             }
-
-                            bool is_full = false;
-                            latency_buffer_full(&is_full, portMAX_DELAY);
-                            if ((is_full == true) &&
-                                (timeout < NORMAL_SYNC_LATENCY_BUF)) {
-                              if (esp_timer_is_active(timeSyncMessageTimer)) {
-                                esp_timer_stop(timeSyncMessageTimer);
-                              }
-
-                              esp_timer_start_periodic(timeSyncMessageTimer,
-                                                       timeout);
-                            }
                           }
                         }
 
@@ -2672,6 +2633,19 @@ static void http_get_task(void *pvParameters) {
                             timeout = NORMAL_SYNC_LATENCY_BUF;
 
                             ESP_LOGI(TAG, "latency buffer full");
+
+                            if (esp_timer_is_active(timeSyncMessageTimer)) {
+                              esp_timer_stop(timeSyncMessageTimer);
+                            }
+
+                            esp_timer_start_periodic(timeSyncMessageTimer,
+                                                     timeout);
+                          }
+                          else if ((is_full == false) &&
+                              (timeout > FAST_SYNC_LATENCY_BUF)){
+                            timeout = FAST_SYNC_LATENCY_BUF;
+
+                            ESP_LOGI(TAG, "latency buffer not full");
 
                             if (esp_timer_is_active(timeSyncMessageTimer)) {
                               esp_timer_stop(timeSyncMessageTimer);


### PR DESCRIPTION
This PR modifies the median filter in a way that it gives a correct output from the first inserted value on.
Basically the buffer is initialized with `INT64_MAX` and only the first `bufferCnt` values are considered. `medianHead` is moved one sample to the right with every second inserted value. If `bufferCnt` is an even value, `medianHead` will be the higher value (of the two center samples). Of course, with little increased complexity this could be changed to give the arithmetic mean.

I have tested these modifications thoroughly and tried to simulate all the edge cases.
I also modified get_median() accordingly and fixed a bug when n>2. Further I remove unneeded/redundant code from http_task.
The median buffer is considered full when 19 samples are inserted: `#define LATENCY_MEDIAN_FILTER_FULL 19`

This PR is also in preparation for the upcoming power saving PR.