### PR TITLE
AI Thinker: Fix volume levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,13 @@ Configure to match your setup
 ```
 idf.py build flash monitor
 ```
+
+### Merge bin to flash at 0x0 with web.esphome.io
+
+```
+esptool.py --chip esp32  merge_bin -o merged.bin --flash_size 4MB --flash_freq 80m 0x1000 build/bootloader/bootloader.bin 0x8000 build/partition_table/partition-table.bin 0xd000 build/ota_data_initial.bin 0x10000 build/snapclient.bin 0x370000 build/storage.bin
+```
+
 ## Test
 Setup a snapcast server on your network
 

--- a/components/audio_hal/driver/es8388/es8388.c
+++ b/components/audio_hal/driver/es8388/es8388.c
@@ -461,8 +461,12 @@ es8388_set_voice_volume (int volume)
    * 33 = 4.5dB
    */
 
-  // restrict range from 0-96 instead of 0-192
-  int inv_volume = -0.96 * volume + 96;
+  // restrict range from 0-46 instead of 0-192
+  int inv_volume = -0.46 * volume + 46;
+  if (volume == 0) {
+    // if volume is 0, set to -96dB
+    inv_volume = 192;
+  }
   res = es_write_reg (ES8388_ADDR, ES8388_DACCONTROL5, inv_volume);
   res |= es_write_reg (ES8388_ADDR, ES8388_DACCONTROL4, inv_volume);
   return res;
@@ -486,9 +490,14 @@ es8388_get_voice_volume (int *volume)
   else
     {
       // 0 = 0dB, 192 = -96dB
-      // max is 0, min is 96
+      // max is 0, min is 46
       // interpolate to 0-100
-      *volume = -(25/24) * reg + 100;
+      if (reg == 192) {
+        *volume = 0;
+      }
+      else {
+        *volume = -(50/23) * reg + 100;
+      }
     }
   return res;
 }

--- a/components/audio_hal/driver/es8388/es8388.c
+++ b/components/audio_hal/driver/es8388/es8388.c
@@ -346,6 +346,10 @@ es8388_init (audio_hal_codec_config_t *cfg)
                        0x80); // set internal ADC and DAC use the same LRCK
                               // clock, ADC LRCK as internal LRCK
   res |= es_write_reg (ES8388_ADDR, ES8388_DACCONTROL23, 0x00); // vroi=0
+  res |= es_write_reg (ES8388_ADDR, ES8388_DACCONTROL24, 0x1E); // Set L1 R1 L2 R2 volume. 0x00: -30dB, 0x1E: 0dB, 0x21: 3dB
+  res |= es_write_reg (ES8388_ADDR, ES8388_DACCONTROL25, 0x1E);
+  res |= es_write_reg (ES8388_ADDR, ES8388_DACCONTROL26, 0x1E);
+  res |= es_write_reg (ES8388_ADDR, ES8388_DACCONTROL27, 0x1E);
   res |= es8388_set_adc_dac_volume (ES_MODULE_DAC, 0, 0);       // 0db
   int tmp = 0;
   if (AUDIO_HAL_DAC_OUTPUT_LINE2 == cfg->dac_output)
@@ -445,7 +449,7 @@ es8388_set_voice_volume (int volume)
     volume = 0;
   else if (volume > 100)
     volume = 100;
-  /* Audio Settings can be checked here: 
+  /* Audio Settings can be checked here:
    * https://dl.radxa.com/rock2/docs/hw/ds/ES8388%20user%20Guide.pdf
    *
    * ES8388_DACCONTROL4 & ES8388_DACCONTROL5
@@ -456,17 +460,11 @@ es8388_set_voice_volume (int volume)
    * 0 = -45dB
    * 33 = 4.5dB
    */
-  
 
-  int inv_volume = (100 - volume)*1.92;
+  // restrict range from 0-96 instead of 0-192
+  int inv_volume = -0.96 * volume + 96;
   res = es_write_reg (ES8388_ADDR, ES8388_DACCONTROL5, inv_volume);
   res |= es_write_reg (ES8388_ADDR, ES8388_DACCONTROL4, inv_volume);
-
-  volume /= 3;
-  res |= es_write_reg (ES8388_ADDR, ES8388_DACCONTROL24, volume);
-  res |= es_write_reg (ES8388_ADDR, ES8388_DACCONTROL25, volume);
-  res |= es_write_reg (ES8388_ADDR, ES8388_DACCONTROL26, volume);
-  res |= es_write_reg (ES8388_ADDR, ES8388_DACCONTROL27, volume);
   return res;
 }
 
@@ -480,17 +478,17 @@ es8388_get_voice_volume (int *volume)
 {
   esp_err_t res = ESP_OK;
   uint8_t reg = 0;
-  res = es_read_reg (ES8388_DACCONTROL24, &reg);
+  res = es_read_reg (ES8388_DACCONTROL4, &reg);
   if (res == ESP_FAIL)
     {
       *volume = 0;
     }
   else
     {
-      *volume = reg;
-      *volume *= 3;
-      if (*volume == 99)
-        *volume = 100;
+      // 0 = 0dB, 192 = -96dB
+      // max is 0, min is 96
+      // interpolate to 0-100
+      *volume = -(25/24) * reg + 100;
     }
   return res;
 }


### PR DESCRIPTION
Follow up to #67 . I found the entire bottom half of the range is completely inaudible. This adjusts the range to only the top 50% of what it used to be. 

The changes to DACCONTROL24-27 appear to not be important to change.