### PR TITLE
Use FreeRTOS v8+ compatible symbols

### DIFF
--- a/components/audio_hal/driver/es8388/headphone_detect.c
+++ b/components/audio_hal/driver/es8388/headphone_detect.c
@@ -36,7 +36,8 @@
 #include "freertos/task.h"
 #include "freertos/timers.h"
 
-#if defined(CONFIG_ESP_LYRAT_V4_3_BOARD) || defined(CONFIG_ESP_AI_THINKER_ES8388_BOARD)
+#if defined(CONFIG_ESP_LYRAT_V4_3_BOARD) || \
+    defined(CONFIG_ESP_AI_THINKER_ES8388_BOARD)
 
 #define HP_DELAY_TIME_MS 1000
 
@@ -51,7 +52,7 @@ static void hp_timer_cb(TimerHandle_t xTimer) {
 
 static int hp_timer_init(int num) {
   timer_headphone =
-      xTimerCreate("hp_timer0", HP_DELAY_TIME_MS / portTICK_RATE_MS, pdFALSE,
+      xTimerCreate("hp_timer0", HP_DELAY_TIME_MS / portTICK_PERIOD_MS, pdFALSE,
                    (void *)num, hp_timer_cb);
   if (timer_headphone == NULL) {
     ESP_LOGE(TAG, "hp_timer create err");
@@ -69,7 +70,7 @@ static void IRAM_ATTR headphone_gpio_intr_handler(void *arg) {
 }
 
 void headphone_detect_deinit() {
-  xTimerDelete(timer_headphone, HP_DELAY_TIME_MS / portTICK_RATE_MS);
+  xTimerDelete(timer_headphone, HP_DELAY_TIME_MS / portTICK_PERIOD_MS);
   gpio_uninstall_isr_service();
   timer_headphone = NULL;
 }
@@ -92,4 +93,5 @@ void headphone_detect_init(int num) {
   gpio_install_isr_service(0);
   gpio_isr_handler_add(num, headphone_gpio_intr_handler, (void *)num);
 }
-#endif /* defined(CONFIG_ESP_LYRAT_V4_3_BOARD) || defined(CONFIG_ESP_AI_THINKER_ES8388_BOARD) */
+#endif /* defined(CONFIG_ESP_LYRAT_V4_3_BOARD) || \
+          defined(CONFIG_ESP_AI_THINKER_ES8388_BOARD) */

--- a/components/audio_hal/driver/tas5805m/tas5805m.c
+++ b/components/audio_hal/driver/tas5805m/tas5805m.c
@@ -95,7 +95,7 @@ static esp_err_t tas5805m_transmit_registers(const tas5805m_cfg_reg_t *conf_buf,
         // Used in legacy applications.  Ignored here.
         break;
       case CFG_META_DELAY:
-        vTaskDelay(conf_buf[i].value / portTICK_RATE_MS);
+        vTaskDelay(conf_buf[i].value / portTICK_PERIOD_MS);
         break;
       case CFG_META_BURST:
         ret = i2c_bus_write_bytes(i2c_handler, TAS5805M_ADDR,
@@ -135,9 +135,9 @@ esp_err_t tas5805m_init(audio_hal_codec_config_t *codec_cfg) {
   io_conf.intr_type = GPIO_INTR_DISABLE;
   gpio_config(&io_conf);
   gpio_set_level(TAS5805M_RST_GPIO, 0);
-  vTaskDelay(20 / portTICK_RATE_MS);
+  vTaskDelay(20 / portTICK_PERIOD_MS);
   gpio_set_level(TAS5805M_RST_GPIO, 1);
-  vTaskDelay(200 / portTICK_RATE_MS);
+  vTaskDelay(200 / portTICK_PERIOD_MS);
 
   ret = get_i2c_pins(I2C_NUM_0, &i2c_cfg);
   i2c_handler = i2c_bus_create(I2C_NUM_0, &i2c_cfg);

--- a/components/audio_hal/include/audio_hal.h
+++ b/components/audio_hal/include/audio_hal.h
@@ -156,7 +156,7 @@ typedef struct audio_hal {
   esp_err_t (*audio_codec_set_volume)(int volume);  /*!< set codec volume */
   esp_err_t (*audio_codec_get_volume)(int *volume); /*!< get codec volume */
   esp_err_t (*audio_codec_enable_pa)(bool enable);  /*!< enable pa */
-  xSemaphoreHandle audio_hal_lock;                  /*!< semaphore of codec */
+  SemaphoreHandle_t audio_hal_lock;                 /*!< semaphore of codec */
   void *handle; /*!< handle of audio codec */
 } audio_hal_func_t;
 

--- a/components/custom_board/ma120/ma120.c
+++ b/components/custom_board/ma120/ma120.c
@@ -271,7 +271,8 @@ esp_err_t ma_write(uint8_t i2c_addr, uint8_t prot, uint16_t address,
     i2c_master_write_byte(cmd, wbuf[i], ack);
   }
   i2c_master_stop(cmd);
-  int ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
+  int ret =
+      i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_PERIOD_MS);
   i2c_cmd_link_delete(cmd);
   if (ret == ESP_FAIL) {
     return ret;
@@ -294,7 +295,7 @@ esp_err_t ma_write_byte(uint8_t i2c_addr, uint8_t prot, uint16_t address,
   }
   i2c_master_write_byte(cmd, value, ACK_VAL);
   i2c_master_stop(cmd);
-  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
+  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_PERIOD_MS);
   i2c_cmd_link_delete(cmd);
   if (ret == ESP_FAIL) {
     printf("ESP_I2C_WRITE ERROR : %d\n", ret);
@@ -326,7 +327,7 @@ esp_err_t ma_read(uint8_t i2c_addr, uint8_t prot, uint16_t address,
   // { i2c_master_read_byte(cmd, rbuf++, ACK_VAL); }
   i2c_master_read_byte(cmd, rbuf + n - 1, NACK_VAL);
   i2c_master_stop(cmd);
-  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 100 / portTICK_RATE_MS);
+  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 100 / portTICK_PERIOD_MS);
   i2c_cmd_link_delete(cmd);
   if (ret == ESP_FAIL) {
     printf("i2c Error read - readback\n");
@@ -353,7 +354,7 @@ uint8_t ma_read_byte(uint8_t i2c_addr, uint8_t prot, uint16_t address) {
   i2c_master_read_byte(cmd, &value, NACK_VAL);
 
   i2c_master_stop(cmd);
-  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
+  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_PERIOD_MS);
   i2c_cmd_link_delete(cmd);
   if (ret == ESP_FAIL) {
     printf("i2c Error read - readback\n");

--- a/components/custom_board/ma120x0/MerusAudio.c
+++ b/components/custom_board/ma120x0/MerusAudio.c
@@ -283,7 +283,8 @@ esp_err_t ma_write(uint8_t i2c_addr, uint8_t prot, uint16_t address,
     i2c_master_write_byte(cmd, wbuf[i], ack);
   }
   i2c_master_stop(cmd);
-  int ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
+  int ret =
+      i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_PERIOD_MS);
   i2c_cmd_link_delete(cmd);
   if (ret == ESP_FAIL) {
     return ret;
@@ -306,7 +307,7 @@ esp_err_t ma_write_byte(uint8_t i2c_addr, uint8_t prot, uint16_t address,
   }
   i2c_master_write_byte(cmd, value, ACK_VAL);
   i2c_master_stop(cmd);
-  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
+  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_PERIOD_MS);
   i2c_cmd_link_delete(cmd);
   if (ret == ESP_FAIL) {
     printf("ESP_I2C_WRITE ERROR : %d\n", ret);
@@ -338,7 +339,7 @@ esp_err_t ma_read(uint8_t i2c_addr, uint8_t prot, uint16_t address,
   // { i2c_master_read_byte(cmd, rbuf++, ACK_VAL); }
   i2c_master_read_byte(cmd, rbuf + n - 1, NACK_VAL);
   i2c_master_stop(cmd);
-  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 100 / portTICK_RATE_MS);
+  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 100 / portTICK_PERIOD_MS);
   i2c_cmd_link_delete(cmd);
   if (ret == ESP_FAIL) {
     printf("i2c Error read - readback\n");
@@ -365,7 +366,7 @@ uint8_t ma_read_byte(uint8_t i2c_addr, uint8_t prot, uint16_t address) {
   i2c_master_read_byte(cmd, &value, NACK_VAL);
 
   i2c_master_stop(cmd);
-  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
+  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_PERIOD_MS);
   i2c_cmd_link_delete(cmd);
   if (ret == ESP_FAIL) {
     printf("i2c Error read - readback\n");

--- a/components/custom_board/pcm51xx/pcm51xx.c
+++ b/components/custom_board/pcm51xx/pcm51xx.c
@@ -106,9 +106,9 @@ io_conf.mode = GPIO_MODE_OUTPUT;
 io_conf.intr_type = GPIO_INTR_DISABLE;
 gpio_config(&io_conf);
 gpio_set_level(PCM51XX_RST_GPIO, 0);
-vTaskDelay(20 / portTICK_RATE_MS);
+vTaskDelay(20 / portTICK_PERIOD_MS);
 gpio_set_level(PCM51XX_RST_GPIO, 1);
-vTaskDelay(200 / portTICK_RATE_MS);
+vTaskDelay(200 / portTICK_PERIOD_MS);
   */
 
   ret = get_i2c_pins(I2C_NUM_0, &i2c_cfg);

--- a/components/custom_board/tas5805m/tas5805m.c
+++ b/components/custom_board/tas5805m/tas5805m.c
@@ -25,6 +25,7 @@
  */
 
 #include "tas5805m.h"
+
 #include "esp_log.h"
 #include "i2c_bus.h"
 #include "tas5805m_reg_cfg.h"
@@ -57,52 +58,45 @@ audio_hal_func_t AUDIO_CODEC_TAS5805M_DEFAULT_HANDLE = {
 
 /* Init the I2C Driver */
 
-void i2c_master_init()
-{
+void i2c_master_init() {
   int i2c_master_port = I2C_MASTER_NUM;
-  
-  
+
   ESP_ERROR_CHECK(get_i2c_pins(I2C_NUM_0, &i2c_cfg));
- 
+
   ESP_ERROR_CHECK(i2c_param_config(i2c_master_port, &i2c_cfg));
-  
- 
- 
+
   ESP_ERROR_CHECK(i2c_driver_install(i2c_master_port, i2c_cfg.mode,
-                           I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE,
-                           0));
-  
+                                     I2C_MASTER_RX_BUF_DISABLE,
+                                     I2C_MASTER_TX_BUF_DISABLE, 0));
 }
 
 /* Helper Functions */
 
-
 // Reading of TAS5805M-Register
 
-esp_err_t tas5805m_read_byte(uint8_t register_name, uint8_t *data)
-{
-
+esp_err_t tas5805m_read_byte(uint8_t register_name, uint8_t *data) {
   int ret;
   i2c_cmd_handle_t cmd = i2c_cmd_link_create();
   i2c_master_start(cmd);
   i2c_master_write_byte(cmd, TAS5805M_ADDRESS << 1 | WRITE_BIT, ACK_CHECK_EN);
   i2c_master_write_byte(cmd, register_name, ACK_CHECK_EN);
   i2c_master_stop(cmd);
-  ret = i2c_master_cmd_begin(I2C_TAS5805M_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
+  ret = i2c_master_cmd_begin(I2C_TAS5805M_MASTER_NUM, cmd,
+                             1000 / portTICK_PERIOD_MS);
   i2c_cmd_link_delete(cmd);
 
-  if (ret != ESP_OK)
-  {
+  if (ret != ESP_OK) {
     ESP_LOGW(TAG, "I2C ERROR");
   }
 
-  vTaskDelay(1 / portTICK_RATE_MS);
+  vTaskDelay(1 / portTICK_PERIOD_MS);
   cmd = i2c_cmd_link_create();
   i2c_master_start(cmd);
   i2c_master_write_byte(cmd, TAS5805M_ADDRESS << 1 | READ_BIT, ACK_CHECK_EN);
   i2c_master_read_byte(cmd, data, NACK_VAL);
   i2c_master_stop(cmd);
-  ret = i2c_master_cmd_begin(I2C_TAS5805M_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
+  ret = i2c_master_cmd_begin(I2C_TAS5805M_MASTER_NUM, cmd,
+                             1000 / portTICK_PERIOD_MS);
   i2c_cmd_link_delete(cmd);
 
   return ret;
@@ -110,24 +104,23 @@ esp_err_t tas5805m_read_byte(uint8_t register_name, uint8_t *data)
 
 // Writing of TAS5805M-Register
 
-esp_err_t tas5805m_write_byte(uint8_t register_name, uint8_t value)
-{
-  int ret =0;
+esp_err_t tas5805m_write_byte(uint8_t register_name, uint8_t value) {
+  int ret = 0;
   i2c_cmd_handle_t cmd = i2c_cmd_link_create();
   i2c_master_start(cmd);
   i2c_master_write_byte(cmd, TAS5805M_ADDRESS << 1 | WRITE_BIT, ACK_CHECK_EN);
   i2c_master_write_byte(cmd, register_name, ACK_CHECK_EN);
   i2c_master_write_byte(cmd, value, ACK_CHECK_EN);
   i2c_master_stop(cmd);
-  
-  ret = i2c_master_cmd_begin(I2C_TAS5805M_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS);
 
- // Check if ret is OK
+  ret = i2c_master_cmd_begin(I2C_TAS5805M_MASTER_NUM, cmd,
+                             1000 / portTICK_PERIOD_MS);
+
+  // Check if ret is OK
   if (ret != ESP_OK) {
     ESP_LOGE(TAG, "Fehler bei der I2C-Übertragung: %s", esp_err_to_name(ret));
-    
   }
-  
+
   i2c_cmd_link_delete(cmd);
 
   return ret;
@@ -135,9 +128,8 @@ esp_err_t tas5805m_write_byte(uint8_t register_name, uint8_t value)
 
 // Inits the TAS5805M change Settings in Menuconfig to enable Bridge-Mode
 
-esp_err_t tas5805m_init()
-{
-  int ret =0;
+esp_err_t tas5805m_init() {
+  int ret = 0;
   // Init the I2C-Driver
   i2c_master_init();
   /* Register the PDN pin as output and write 1 to enable the TAS chip */
@@ -151,141 +143,118 @@ esp_err_t tas5805m_init()
   ESP_LOGW(TAG, "Power down pin: %d", TAS5805M_GPIO_PDN);
   gpio_config(&io_conf);
   gpio_set_level(TAS5805M_GPIO_PDN, 0);
-  vTaskDelay(10 / portTICK_RATE_MS);
+  vTaskDelay(10 / portTICK_PERIOD_MS);
   gpio_set_level(TAS5805M_GPIO_PDN, 1);
-  vTaskDelay(10 / portTICK_RATE_MS);
+  vTaskDelay(10 / portTICK_PERIOD_MS);
 
   /* TAS5805M.Begin()*/
 
   ESP_LOGW(TAG, "Setting to HI Z");
 
   ESP_ERROR_CHECK(tas5805m_write_byte(TAS5805M_DEVICE_CTRL_2_REGISTER, 0x02));
-  vTaskDelay(10 / portTICK_RATE_MS);
-  if (ret != ESP_OK){
+  vTaskDelay(10 / portTICK_PERIOD_MS);
+  if (ret != ESP_OK) {
     ESP_LOGW(TAG, "TAS5805M_DEVICE_CTRL_2_REGISTER, 0x02 FAILED!!!");
     return ret;
   }
-    
-  ESP_LOGW(TAG, "Setting to PLAY");
-  
-  ret = tas5805m_write_byte(TAS5805M_DEVICE_CTRL_2_REGISTER, 0x03);
-  if (ret != ESP_OK){
-    ESP_LOGW(TAG, "TAS5805M_DEVICE_CTRL_2_REGISTER, 0x03 FAILED!!");
-     return ret;
-  }
-     
 
-    // Check if Bridge-Mode is enabled
-  #ifdef CONFIG_DAC_BRIDGE_MODE
+  ESP_LOGW(TAG, "Setting to PLAY");
+
+  ret = tas5805m_write_byte(TAS5805M_DEVICE_CTRL_2_REGISTER, 0x03);
+  if (ret != ESP_OK) {
+    ESP_LOGW(TAG, "TAS5805M_DEVICE_CTRL_2_REGISTER, 0x03 FAILED!!");
+    return ret;
+  }
+
+  // Check if Bridge-Mode is enabled
+#ifdef CONFIG_DAC_BRIDGE_MODE
   uint8_t value = 0;
   ret = tas5805m_read_byte(TAS5805M_DEVICE_CTRL_1_REGISTER, &value);
-  if (ret != ESP_OK)
-    return ret;
+  if (ret != ESP_OK) return ret;
   value = 0b100;
-  
+
   ret = tas5805m_write_byte(TAS5805M_DEVICE_CTRL_1_REGISTER, value);
-  if (ret != ESP_OK)
-    return ret;
-  #endif
+  if (ret != ESP_OK) return ret;
+#endif
 
   return ret;
 }
 
 // Setting the Volume
 
-esp_err_t
-tas5805m_set_volume(int vol)
-{
-  int vol_idx = 0; // Temp-Variable 
+esp_err_t tas5805m_set_volume(int vol) {
+  int vol_idx = 0;  // Temp-Variable
 
   /* Checking if Volume is bigger or smaller than the max values */
-  if (vol < TAS5805M_VOLUME_MIN)
-    {
-      vol = TAS5805M_VOLUME_MIN;
-    }
-  if (vol > TAS5805M_VOLUME_MAX)
-    {
-      vol = TAS5805M_VOLUME_MAX;
-    }
+  if (vol < TAS5805M_VOLUME_MIN) {
+    vol = TAS5805M_VOLUME_MIN;
+  }
+  if (vol > TAS5805M_VOLUME_MAX) {
+    vol = TAS5805M_VOLUME_MAX;
+  }
   /* Mapping the Values from 0-100 to 254-0 */
-  vol_idx = vol / 5; 
+  vol_idx = vol / 5;
   /* Updating the global volume Variable */
   currentVolume = vol_idx;
   /* Writing the Volume to the Register*/
-  return tas5805m_write_byte(TAS5805M_DIG_VOL_CTRL_REGISTER, tas5805m_volume[vol_idx]);
+  return tas5805m_write_byte(TAS5805M_DIG_VOL_CTRL_REGISTER,
+                             tas5805m_volume[vol_idx]);
 }
 
-esp_err_t 
-tas5805m_get_volume(int *vol)
-{
+esp_err_t tas5805m_get_volume(int *vol) {
   esp_err_t ret = ESP_OK;
   uint8_t rxbuf = 0;
   ret = tas5805m_read_byte(TAS5805M_DIG_VOL_CTRL_REGISTER, &rxbuf);
   int i;
-  for (i = 0; i < sizeof (tas5805m_volume); i++)
-    {
-      if (rxbuf>= tas5805m_volume[i])
-        break;
-    }
+  for (i = 0; i < sizeof(tas5805m_volume); i++) {
+    if (rxbuf >= tas5805m_volume[i]) break;
+  }
   /* Updating the global volume Variable */
-  currentVolume = i; 
-  ESP_LOGI (TAG, "Volume is %d", i * 5);
-  *vol = 5 * i; // Converting it to percent
+  currentVolume = i;
+  ESP_LOGI(TAG, "Volume is %d", i * 5);
+  *vol = 5 * i;  // Converting it to percent
   return ret;
 }
 
-esp_err_t tas5805m_deinit(void)
-{
+esp_err_t tas5805m_deinit(void) {
   // TODO
   return ESP_OK;
 }
 
-
-
-esp_err_t
-tas5805m_set_mute(bool enable)
-{
-  
-  if (enable == true)
-  {
+esp_err_t tas5805m_set_mute(bool enable) {
+  if (enable == true) {
     // Set the Volume to 255 to enable the MUTE
-    return tas5805m_write_byte(TAS5805M_DIG_VOL_CTRL_REGISTER, TAS5805M_VOLUME_MUTE);
-  }
-  else{
-    return tas5805m_write_byte(TAS5805M_DIG_VOL_CTRL_REGISTER,tas5805m_volume[currentVolume]); // Restore Volume to its old value
+    return tas5805m_write_byte(TAS5805M_DIG_VOL_CTRL_REGISTER,
+                               TAS5805M_VOLUME_MUTE);
+  } else {
+    return tas5805m_write_byte(
+        TAS5805M_DIG_VOL_CTRL_REGISTER,
+        tas5805m_volume[currentVolume]);  // Restore Volume to its old value
   }
   return ESP_OK;
 }
 
-esp_err_t
-tas5805m_get_mute(bool *enabled)
-{
+esp_err_t tas5805m_get_mute(bool *enabled) {
   int currentVolume;
-  if (tas5805m_get_volume(&currentVolume) != ESP_OK)
-  {
+  if (tas5805m_get_volume(&currentVolume) != ESP_OK) {
     ESP_LOGW(TAG, "Cant get volume in get-Mute-Function");
   }
-  if (currentVolume == TAS5805M_VOLUME_MUTE)
-  {
+  if (currentVolume == TAS5805M_VOLUME_MUTE) {
     *enabled = true;
-  }
-  else
-  {
+  } else {
     *enabled = false;
   }
   return ESP_OK;
 }
 
 esp_err_t tas5805m_ctrl(audio_hal_codec_mode_t mode,
-                        audio_hal_ctrl_t ctrl_state)
-{
+                        audio_hal_ctrl_t ctrl_state) {
   // TODO
   return ESP_OK;
 }
 
 esp_err_t tas5805m_config_iface(audio_hal_codec_mode_t mode,
-                                audio_hal_codec_i2s_iface_t *iface)
-{
+                                audio_hal_codec_i2s_iface_t *iface) {
   // TODO
   return ESP_OK;
 }

--- a/components/esp_peripherals/driver/i2c_bus/i2c_bus.c
+++ b/components/esp_peripherals/driver/i2c_bus/i2c_bus.c
@@ -45,10 +45,10 @@
   }
 
 typedef struct {
-  i2c_config_t i2c_conf;     /*!<I2C bus parameters*/
-  i2c_port_t i2c_port;       /*!<I2C port number */
-  int ref_count;             /*!<Reference Count for multiple client */
-  xSemaphoreHandle bus_lock; /*!<Lock for bus */
+  i2c_config_t i2c_conf;      /*!<I2C bus parameters*/
+  i2c_port_t i2c_port;        /*!<I2C port number */
+  int ref_count;              /*!<Reference Count for multiple client */
+  SemaphoreHandle_t bus_lock; /*!<Lock for bus */
 } i2c_bus_t;
 
 static const char *TAG = "I2C_BUS";
@@ -116,7 +116,7 @@ esp_err_t i2c_bus_write_bytes(i2c_bus_handle_t bus, int addr, uint8_t *reg,
   ret |= i2c_master_write(cmd, reg, regLen, I2C_ACK_CHECK_EN);
   ret |= i2c_master_write(cmd, data, datalen, I2C_ACK_CHECK_EN);
   ret |= i2c_master_stop(cmd);
-  ret |= i2c_master_cmd_begin(p_bus->i2c_port, cmd, 1000 / portTICK_RATE_MS);
+  ret |= i2c_master_cmd_begin(p_bus->i2c_port, cmd, 1000 / portTICK_PERIOD_MS);
   i2c_cmd_link_delete(cmd);
   mutex_unlock(p_bus->bus_lock);
   I2C_BUS_CHECK(ret == 0, "I2C Bus WriteReg Error", ESP_FAIL);
@@ -136,7 +136,7 @@ esp_err_t i2c_bus_write_data(i2c_bus_handle_t bus, int addr, uint8_t *data,
   ret |= i2c_master_write_byte(cmd, addr, 1);
   ret |= i2c_master_write(cmd, data, datalen, I2C_ACK_CHECK_EN);
   ret |= i2c_master_stop(cmd);
-  ret |= i2c_master_cmd_begin(p_bus->i2c_port, cmd, 1000 / portTICK_RATE_MS);
+  ret |= i2c_master_cmd_begin(p_bus->i2c_port, cmd, 1000 / portTICK_PERIOD_MS);
   i2c_cmd_link_delete(cmd);
   mutex_unlock(p_bus->bus_lock);
   I2C_BUS_CHECK(ret == 0, "I2C Bus WriteReg Error", ESP_FAIL);
@@ -158,7 +158,7 @@ esp_err_t i2c_bus_read_bytes(i2c_bus_handle_t bus, int addr, uint8_t *reg,
   ret |= i2c_master_write_byte(cmd, addr, I2C_ACK_CHECK_EN);
   ret |= i2c_master_write(cmd, reg, reglen, I2C_ACK_CHECK_EN);
   ret |= i2c_master_stop(cmd);
-  ret |= i2c_master_cmd_begin(p_bus->i2c_port, cmd, 1000 / portTICK_RATE_MS);
+  ret |= i2c_master_cmd_begin(p_bus->i2c_port, cmd, 1000 / portTICK_PERIOD_MS);
   i2c_cmd_link_delete(cmd);
 
   cmd = i2c_cmd_link_create();
@@ -171,7 +171,7 @@ esp_err_t i2c_bus_read_bytes(i2c_bus_handle_t bus, int addr, uint8_t *reg,
   ret |= i2c_master_read_byte(cmd, &outdata[datalen - 1], 1);
 
   ret |= i2c_master_stop(cmd);
-  ret |= i2c_master_cmd_begin(p_bus->i2c_port, cmd, 1000 / portTICK_RATE_MS);
+  ret |= i2c_master_cmd_begin(p_bus->i2c_port, cmd, 1000 / portTICK_PERIOD_MS);
   i2c_cmd_link_delete(cmd);
 
   mutex_unlock(p_bus->bus_lock);

--- a/components/esp_peripherals/esp_peripherals.c
+++ b/components/esp_peripherals/esp_peripherals.c
@@ -38,7 +38,7 @@
 
 static const char *TAG = "ESP_PERIPH";
 
-#define DEFAULT_ESP_PERIPH_WAIT_TICK (10 / portTICK_RATE_MS)
+#define DEFAULT_ESP_PERIPH_WAIT_TICK (10 / portTICK_PERIOD_MS)
 
 struct esp_periph {
   char *tag;
@@ -57,7 +57,7 @@ struct esp_periph {
 
 typedef struct esp_periph_sets {
   EventGroupHandle_t state_event_bits;
-  xSemaphoreHandle lock;
+  SemaphoreHandle_t lock;
   int task_stack;
   int task_prio;
   int task_core;
@@ -93,7 +93,7 @@ esp_err_t esp_periph_set_change_waiting_time(
     esp_periph_set_handle_t periph_set_handle, int time_ms) {
   audio_event_iface_set_cmd_waiting_timeout(
       esp_periph_set_get_event_iface(periph_set_handle),
-      time_ms / portTICK_RATE_MS);
+      time_ms / portTICK_PERIOD_MS);
   return ESP_OK;
 }
 

--- a/components/esp_peripherals/periph_button.c
+++ b/components/esp_peripherals/periph_button.c
@@ -106,7 +106,7 @@ static esp_err_t _button_init(esp_periph_handle_t self) {
   };
   periph_btn->btn = button_init(&btn_config);
 
-  esp_periph_start_timer(self, 50 / portTICK_RATE_MS, button_timer_handler);
+  esp_periph_start_timer(self, 50 / portTICK_PERIOD_MS, button_timer_handler);
   return ret;
 }
 

--- a/components/esp_peripherals/periph_console.c
+++ b/components/esp_peripherals/periph_console.c
@@ -218,7 +218,7 @@ static void _console_task(void *pv) {
   printf("\r\n%s ", prompt_string);
   while (console->run) {
     if (console_get_line(console, console->buffer_size,
-                         10 / portTICK_RATE_MS)) {
+                         10 / portTICK_PERIOD_MS)) {
       if (console->total_bytes) {
         ESP_LOGD(TAG, "Read line: %s", console->buffer);
       }

--- a/components/esp_peripherals/periph_led.c
+++ b/components/esp_peripherals/periph_led.c
@@ -234,7 +234,7 @@ esp_err_t periph_led_blink(esp_periph_handle_t periph, int gpio_num,
   }
   ch->stop = false;
   ch->level = level;
-  esp_periph_start_timer(periph, portTICK_RATE_MS, led_timer_handler);
+  esp_periph_start_timer(periph, portTICK_PERIOD_MS, led_timer_handler);
   return ESP_OK;
 }
 

--- a/components/esp_peripherals/periph_sdcard.c
+++ b/components/esp_peripherals/periph_sdcard.c
@@ -98,7 +98,7 @@ static esp_err_t _sdcard_init(esp_periph_handle_t self) {
   } else {
     ESP_LOGE(TAG, "no sdcard detect");
   }
-  esp_periph_start_timer(self, 1000 / portTICK_RATE_MS, sdcard_timer_handler);
+  esp_periph_start_timer(self, 1000 / portTICK_PERIOD_MS, sdcard_timer_handler);
   return ESP_OK;
 }
 

--- a/components/esp_peripherals/periph_wifi.c
+++ b/components/esp_peripherals/periph_wifi.c
@@ -346,9 +346,9 @@ static void _wifi_event_callback(void *arg, esp_event_base_t event_base,
     if (periph_wifi->disable_auto_reconnect) {
       return;
     }
-    esp_periph_start_timer(self,
-                           periph_wifi->reconnect_timeout_ms / portTICK_RATE_MS,
-                           wifi_reconnect_timer);
+    esp_periph_start_timer(
+        self, periph_wifi->reconnect_timeout_ms / portTICK_PERIOD_MS,
+        wifi_reconnect_timer);
 
   } else {
     ESP_LOGW(TAG, "WiFi Event cb, Unhandle event_base:%s, event_id:%d",
@@ -395,10 +395,12 @@ static esp_err_t _wifi_event_callback(void *ctx, system_event_t *event) {
         break;
       }
       esp_periph_start_timer(
-          self, periph_wifi->reconnect_timeout_ms / portTICK_RATE_MS,
+          self, periph_wifi->reconnect_timeout_ms / portTICK_PERIOD_MS,
           wifi_reconnect_timer);
       break;
     default:
+      ESP_LOGW(TAG, "WiFi Event cb, Unhandled event_id: 0x%08X",
+               event->event_id);
       break;
   }
   return ESP_OK;

--- a/components/esp_peripherals/periph_ws2812.c
+++ b/components/esp_peripherals/periph_ws2812.c
@@ -90,7 +90,7 @@ typedef struct periph_ws2812 {
   periph_rgb_value *color;
   uint32_t led_num;
   TimerHandle_t timer;
-  xSemaphoreHandle sem;
+  SemaphoreHandle_t sem;
   intr_handle_t rmt_intr_handle;
   periph_ws2812_state_t *state;
   periph_ws2812_process_t process;
@@ -404,7 +404,7 @@ esp_err_t periph_ws2812_control(esp_periph_handle_t periph,
     periph_ws2812->state[i].mode = control_cfg[i].mode;
   }
 
-  esp_periph_start_timer(periph, INTERVAL_TIME_MS / portTICK_RATE_MS,
+  esp_periph_start_timer(periph, INTERVAL_TIME_MS / portTICK_PERIOD_MS,
                          ws2812_timer_handler);
 
   return ESP_OK;

--- a/components/esp_peripherals/test/esp_peripherals_test.c
+++ b/components/esp_peripherals/test/esp_peripherals_test.c
@@ -214,7 +214,7 @@ static void periph_console_test(void) {
   TEST_ASSERT_FALSE(esp_periph_start(set, console_handle));
 
   while (task_flag) {
-    vTaskDelay(10 / portTICK_RATE_MS);
+    vTaskDelay(10 / portTICK_PERIOD_MS);
   }
 
   ESP_LOGI(TAG, "Quit test, release all resources");
@@ -295,7 +295,7 @@ static void periph_is31fl3216_test(void) {
       periph_is31fl3216_set_state(is31fl3216_handle, IS31FL3216_STATE_SHIFT));
   ESP_LOGI(TAG, "Start testing for 5 seconds...");
 
-  vTaskDelay(5000 / portTICK_RATE_MS);
+  vTaskDelay(5000 / portTICK_PERIOD_MS);
 
   ESP_LOGI(TAG, "Quit test, release all resources");
   TEST_ASSERT_FALSE(esp_periph_set_stop_all(set));
@@ -326,11 +326,11 @@ static void periph_led_test(void) {
                                      false, 4, 0));
 
   ESP_LOGI(TAG, "running...");
-  vTaskDelay(1000 / portTICK_RATE_MS);
+  vTaskDelay(1000 / portTICK_PERIOD_MS);
   ESP_LOGI(TAG, "STOP BLUE LED");
   TEST_ASSERT_FALSE(periph_led_stop(led_handle, get_blue_led_gpio()));
 
-  vTaskDelay(1000 / portTICK_RATE_MS);
+  vTaskDelay(1000 / portTICK_PERIOD_MS);
   ESP_LOGI(TAG, "Changing blink preset...");
   TEST_ASSERT_FALSE(periph_led_blink(led_handle, get_blue_led_gpio(), 500, 200,
                                      false, -1, 0));

--- a/components/ota_server/ota_server.c
+++ b/components/ota_server/ota_server.c
@@ -20,7 +20,7 @@
 #include "ota_server.h"
 #include "player.h"
 
-extern xTaskHandle t_http_get_task;
+extern TaskHandle_t t_http_get_task;
 
 const int OTA_CONNECTED_BIT = BIT0;
 static const char *TAG = "OTA";


### PR DESCRIPTION
Allows disabling backwards compatibility, which is not enabled by default since IDF 5.

Since these symbols have been stable for many years now, it's time to let them go.
- portTICK_RATE_MS renamed to portTICK_PERIOD_MS
- xSemaphoreHandle renamed to SemaphoreHandle_t
- xTaskHandle renamed to TaskHandle_t

Fixes problems like #91 