### PR TITLE
Allow to use components from C++

### DIFF
--- a/components/audio_hal/driver/es8388/headphone_detect.c
+++ b/components/audio_hal/driver/es8388/headphone_detect.c
@@ -42,7 +42,7 @@
 #define HP_DELAY_TIME_MS 1000
 
 static const char *TAG = "HEADPHONE";
-static xTimerHandle timer_headphone;
+static TimerHandle_t timer_headphone;
 
 static void hp_timer_cb(TimerHandle_t xTimer) {
   int num = (int)pvTimerGetTimerID(xTimer);

--- a/components/dsp_processor/include/dsp_processor.h
+++ b/components/dsp_processor/include/dsp_processor.h
@@ -1,6 +1,10 @@
 #ifndef _DSP_PROCESSOR_H_
 #define _DSP_PROCESSOR_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_err.h"
 
 typedef enum dspFlows {
@@ -63,5 +67,9 @@ void dsp_processor_uninit(void);
 int dsp_processor_worker(char *audio, size_t chunk_size, uint32_t samplerate);
 esp_err_t dsp_processor_update_filter_params(filterParams_t *params);
 void dsp_processor_set_volome(double volume);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _DSP_PROCESSOR_H_  */

--- a/components/lightsnapcast/include/player.h
+++ b/components/lightsnapcast/include/player.h
@@ -1,11 +1,15 @@
 #ifndef __PLAYER_H__
 #define __PLAYER_H__
 
-#include "driver/i2s.h"
+#include "driver/i2s_std.h"
 #include "esp_types.h"
 #include "freertos/FreeRTOS.h"
 #include "sdkconfig.h"
 #include "snapcast.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define I2S_PORT I2S_NUM_0
 
@@ -77,5 +81,7 @@ int32_t get_diff_to_server(int64_t *tDiff);
 int32_t server_now(int64_t *sNow, int64_t *diff2Server);
 
 int32_t pcm_chunk_queue_msg_waiting(void);
-
+#ifdef __cplusplus
+}
+#endif
 #endif  // __PLAYER_H__

--- a/components/lightsnapcast/include/snapcast.h
+++ b/components/lightsnapcast/include/snapcast.h
@@ -1,6 +1,10 @@
 #ifndef __SNAPCAST_H__
 #define __SNAPCAST_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -114,5 +118,7 @@ typedef struct time_message
 int time_message_serialize (time_message_t *msg, char *data, uint32_t size);
 int time_message_deserialize (time_message_t *msg, const char *data,
                               uint32_t size);
-
+#ifdef __cplusplus
+}
+#endif
 #endif // __SNAPCAST_H__

--- a/components/net_functions/include/net_functions.h
+++ b/components/net_functions/include/net_functions.h
@@ -1,6 +1,10 @@
 #ifndef _NET_FUNCTIONS_H_
 #define _NET_FUNCTIONS_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "mdns.h"
 
 #define SNTP_TIMEZONE CONFIG_SNTP_TIMEZONE
@@ -12,5 +16,9 @@ void mdns_print_results(mdns_result_t* results);
 uint32_t find_mdns_service(const char* service_name, const char* proto);
 
 void set_time_from_sntp(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _NET_FUNCTIONS_H_ */

--- a/components/ui_http_server/include/ui_http_server.h
+++ b/components/ui_http_server/include/ui_http_server.h
@@ -1,6 +1,10 @@
 #ifndef __UI_HTTP_SERVER_H__
 #define __UI_HTTP_SERVER_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void init_http_server_task(char *key);
 
 typedef struct {
@@ -10,5 +14,9 @@ typedef struct {
   float gain_2;
   float gain_3;
 } URL_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // __UI_HTTP_SERVER_H__


### PR DESCRIPTION
Wrapping the C headers in `extern "C" {}` allows to include them in C++ files.
Also fix two small idf 5 issues.