### PR TITLE
Fix pcm51xx driver

### DIFF
--- a/components/audio_hal/driver/es8388/es8388.c
+++ b/components/audio_hal/driver/es8388/es8388.c
@@ -536,7 +536,7 @@ esp_err_t es8388_get_voice_mute(void) {
  *     - (-1) Parameter error
  *     - (0)   Success
  */
-esp_err_t es8388_config_dac_output(int output) {
+esp_err_t es8388_config_dac_output(es_dac_output_t output) {
   esp_err_t res;
   uint8_t reg = 0;
   res = es_read_reg(ES8388_DACPOWER, &reg);

--- a/components/custom_board/pcm51xx/pcm51xx.c
+++ b/components/custom_board/pcm51xx/pcm51xx.c
@@ -97,9 +97,9 @@ static esp_err_t pcm51xx_transmit_registers(const pcm51xx_cfg_reg_t *conf_buf,
 
 esp_err_t pcm51xx_init(audio_hal_codec_config_t *codec_cfg) {
   esp_err_t ret = ESP_OK;
-  ESP_LOGI(TAG, "Power ON CODEC with GPIO %d", PCM51XX_RST_GPIO);
   // probably unnecessary...
   /*
+ESP_LOGI(TAG, "Power ON CODEC with GPIO %d", PCM51XX_RST_GPIO);
 gpio_config_t io_conf;
 io_conf.pin_bit_mask = BIT64(PCM51XX_RST_GPIO);
 io_conf.mode = GPIO_MODE_OUTPUT;

--- a/components/esp_peripherals/driver/i2c_bus/i2c_bus.c
+++ b/components/esp_peripherals/driver/i2c_bus/i2c_bus.c
@@ -134,7 +134,9 @@ esp_err_t i2c_bus_write_data(i2c_bus_handle_t bus, int addr, uint8_t *data,
   i2c_cmd_handle_t cmd = i2c_cmd_link_create();
   ret |= i2c_master_start(cmd);
   ret |= i2c_master_write_byte(cmd, addr, 1);
-  ret |= i2c_master_write(cmd, data, datalen, I2C_ACK_CHECK_EN);
+  if (datalen) {
+    ret |= i2c_master_write(cmd, data, datalen, I2C_ACK_CHECK_EN);
+  }
   ret |= i2c_master_stop(cmd);
   ret |= i2c_master_cmd_begin(p_bus->i2c_port, cmd, 1000 / portTICK_PERIOD_MS);
   i2c_cmd_link_delete(cmd);

--- a/main/main.c
+++ b/main/main.c
@@ -22,7 +22,7 @@
 #include "freertos/projdefs.h"
 #include "freertos/task.h"
 #include "hal/gpio_types.h"
-#include "idf_additions.h"
+#include "freertos/idf_additions.h"
 #include "lwip/ip_addr.h"
 #include "lwip/netif.h"
 #if CONFIG_SNAPCLIENT_USE_INTERNAL_ETHERNET || \


### PR DESCRIPTION
The i2c address looking routine was incorrect making the pcm51xx unusable.

Also fix a small typing issue in the es8388 board and an #include statement in the main.c file.

With this fix, the firmware somewhat works with a simple ESP32 (WROOM32) + pcm5142 board. Works but does a lot of RESYNCING HARD (with playing hang) and reboot from time to time.

