### PR TITLE
Allow using pcm510a without dedicated mute pin.

### DIFF
--- a/components/custom_board/pcm5102a/pcm5102a.c
+++ b/components/custom_board/pcm5102a/pcm5102a.c
@@ -42,6 +42,10 @@ esp_err_t pcm5102a_init(audio_hal_codec_config_t *codec_cfg) {
 
   gpio_config_t io_conf;
 
+  if (CONFIG_PCM5102A_MUTE_PIN < 0) {
+    return ESP_OK;
+  }
+
   io_conf.intr_type = GPIO_INTR_DISABLE;
   io_conf.mode = GPIO_MODE_OUTPUT;
   io_conf.pin_bit_mask = (1ULL << CONFIG_PCM5102A_MUTE_PIN);
@@ -65,12 +69,20 @@ esp_err_t pcm5102a_set_volume(int vol) { return ESP_OK; }
 esp_err_t pcm5102a_get_volume(int *value) { return ESP_OK; }
 
 esp_err_t pcm5102a_set_mute(bool enable) {
+  if (CONFIG_PCM5102A_MUTE_PIN < 0) {
+    return ESP_OK;
+  }
+
   return gpio_set_level(CONFIG_PCM5102A_MUTE_PIN, enable ? 0 : 1);
 }
 
 esp_err_t pcm5102a_get_mute(bool *enabled) { return ESP_OK; }
 
 esp_err_t pcm5102a_deinit(void) {
+  if (CONFIG_PCM5102A_MUTE_PIN < 0) {
+    return ESP_OK;
+  }
+
   return gpio_reset_pin(CONFIG_PCM5102A_MUTE_PIN);
 }
 


### PR DESCRIPTION
This allows disable using a dedicated mute pin. Setting the pin number to -1 (or any other negative integer) will gracefully skip all GPIO operations involving the mute pin.