### PR TITLE
Enable WPA3 for static wifi config

### DIFF
--- a/components/audio_board/Kconfig.projbuild
+++ b/components/audio_board/Kconfig.projbuild
@@ -172,13 +172,25 @@ menu "Audio Board"
 	    endmenu
 
 	    menu "DAC-Operation-Mode"
-			 depends on DAC_TAS5805M
+			depends on DAC_TAS5805M
 
-	         config DAC_BRIDGE_MODE
-	            bool "Enable Bridge-Mode"
-	            default false if DAC_TAS5805M
-	            help
-	                If enabled left channel will be played with more power. To use the right channel please change Word-Select-Setting in Logic-Level-Settings.
+	        choice DAC_BRIDGE_MODE
+	            prompt "Bridge-Mode selection"
+	            default DAC_BRIDGE_MODE_DISABLED
+
+				config DAC_BRIDGE_MODE_DISABLED
+					bool "Stereo (bridge mode disabled)"
+
+				config DAC_BRIDGE_MODE_MONO
+					bool "Mono mode (Left + Right / 2)"
+				
+				config DAC_BRIDGE_MODE_LEFT
+					bool "Output left input channel"
+
+				config DAC_BRIDGE_MODE_RIGHT
+					bool "Output right input channel"
+	        
+			endchoice
 		endmenu
 
 		menu "Merus MA120x0 interface Configuration"

--- a/components/custom_board/pcm5102a/pcm5102a.c
+++ b/components/custom_board/pcm5102a/pcm5102a.c
@@ -42,6 +42,10 @@ esp_err_t pcm5102a_init(audio_hal_codec_config_t *codec_cfg) {
 
   gpio_config_t io_conf;
 
+  if (CONFIG_PCM5102A_MUTE_PIN < 0) {
+    return ESP_OK;
+  }
+
   io_conf.intr_type = GPIO_INTR_DISABLE;
   io_conf.mode = GPIO_MODE_OUTPUT;
   io_conf.pin_bit_mask = (1ULL << CONFIG_PCM5102A_MUTE_PIN);
@@ -65,12 +69,20 @@ esp_err_t pcm5102a_set_volume(int vol) { return ESP_OK; }
 esp_err_t pcm5102a_get_volume(int *value) { return ESP_OK; }
 
 esp_err_t pcm5102a_set_mute(bool enable) {
+  if (CONFIG_PCM5102A_MUTE_PIN < 0) {
+    return ESP_OK;
+  }
+
   return gpio_set_level(CONFIG_PCM5102A_MUTE_PIN, enable ? 0 : 1);
 }
 
 esp_err_t pcm5102a_get_mute(bool *enabled) { return ESP_OK; }
 
 esp_err_t pcm5102a_deinit(void) {
+  if (CONFIG_PCM5102A_MUTE_PIN < 0) {
+    return ESP_OK;
+  }
+
   return gpio_reset_pin(CONFIG_PCM5102A_MUTE_PIN);
 }
 

--- a/components/wifi_interface/wifi_interface.c
+++ b/components/wifi_interface/wifi_interface.c
@@ -183,7 +183,7 @@ void wifi_init(void) {
               .ssid = WIFI_SSID,
               .password = WIFI_PASSWORD,
               .sort_method = WIFI_CONNECT_AP_BY_SIGNAL,
-              .threshold.authmode = WIFI_AUTH_WPA2_PSK,
+              .threshold.authmode = WIFI_AUTH_WPA2_WPA3_PSK,
               .pmf_cfg = {.capable = true, .required = false},
           },
   };


### PR DESCRIPTION
Small addition I had locally since a long time to use WPA3 for WiFi if available (only applies to static configuration without provisioning)