### PR TITLE
Fix idf 5.4 build errors

### DIFF
--- a/components/audio_hal/driver/es8388/es8388.c
+++ b/components/audio_hal/driver/es8388/es8388.c
@@ -536,7 +536,7 @@ esp_err_t es8388_get_voice_mute(void) {
  *     - (-1) Parameter error
  *     - (0)   Success
  */
-esp_err_t es8388_config_dac_output(int output) {
+esp_err_t es8388_config_dac_output(es_dac_output_t output) {
   esp_err_t res;
   uint8_t reg = 0;
   res = es_read_reg(ES8388_DACPOWER, &reg);

--- a/components/lightsnapcast/snapcast.c
+++ b/components/lightsnapcast/snapcast.c
@@ -257,7 +257,7 @@ int wire_chunk_message_deserialize(wire_chunk_message_t *msg, const char *data,
 
   result |= buffer_read_int32(&buffer, &(msg->timestamp.sec));
   result |= buffer_read_int32(&buffer, &(msg->timestamp.usec));
-  result |= buffer_read_uint32(&buffer, &(msg->size));
+  result |= buffer_read_uint32(&buffer, (uint32_t *)&(msg->size));
 
   // If there's been an error already (especially for the size bit) return
   // early


### PR DESCRIPTION
There are some small type errors when building with newer C++ versions. Previous type mismatches (typedefs to the same type) were ignored but now trigger errors. See the changes. There are similar small errors in flac and opus submodules which I have fixed locally. What is the best way you suggest to integrate them? We can try to open pull requests to those repos or keep the changes in a fork