### PR TITLE
Fix issue where 100% volume is not restored after reboot

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -453,7 +453,6 @@ void audio_set_mute(bool mute) {
  *
  */
 void audio_set_volume(int volume) {
-  ESP_LOGE(TAG, "set volume %d called.", volume);
   xSemaphoreTake(audioDACSemaphore, portMAX_DELAY);
   if (volume != audioDAC_data.volume) {
     audioDAC_data.volume = volume;


### PR DESCRIPTION
When the volume of the snapclient is set to 100%, the volume was too low when the devices was booted. The reason appears to be a combination of the following:
- The initial volume of the audio hardware is far smaller than 100%
- The initial volume of the `audioDAC_data` struct (which has the job of buffering inputs to the hardware for future reference) is 100%, not matching the hardware's volume
- `audio_set_volume` will not resend a volume change to the same volume.

The issue could be fixed in two ways:
 - ensure that `audioDAC_data`'s initial values perfectly match the hardware's
 - use values representing "unknown state" in `audioDAC_data`'s initial state, to force sending initial setings to the hardware.
 
 I implemented the latter approach for the volume in this PR.
 
 (If I'm not mistaken a similar issue exists for the mute state, so maybe storing it in a 3-way enum and using "unknown" as the initial value might fix that problem as well. )
 
 