### PR TITLE
TAS5805M proper mute and power states implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ local.properties
 .sts4-cache/
 
 # End of https://www.toptal.com/developers/gitignore/api/c,c++,eclipse
+.vscode-ctags

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,39 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Start Docker Container for Build",
+            "type": "shell",
+            "command": "docker run --rm -it -v .:/project -w /project -v /dev:/dev --privileged espressif/idf:v5.1.1",
+            "problemMatcher": []
+        },
+        {
+            "label": "Build, Flash and Monitor (Docker)",
+            "type": "shell",
+            "command": "docker run --rm -it -v ${workspaceFolder}:/project -w /project -v /dev:/dev --privileged espressif/idf:v5.1.1 /bin/bash -c '. $IDF_PATH/export.sh && idf.py build flash monitor'",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "panel": "shared"
+            },
+            "problemMatcher": {
+                "owner": "cpp",
+                "fileLocation": ["relative", "${workspaceFolder}"],
+                "pattern": {
+                    "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This change is intended to fix the MUTE state on the TAS5805M DAC.

Currently, it is implemented as digital volume control, so it will send `0xff` into `TAS5805M_DIG_VOL_CTRL_REGISTER` to mute. The problems with this approach are
- DAC still uses extra power, keeping output drivers running all the time
- (Critical) When softvolume is used, DAC is muted while not playing, but never unmuted, since digital volume control is not used on DAC, to it stays muted forever

Proposed approach using DAC built-in power states to change the MUTE state, so this digital volume is preserved.