### PR TITLE
Validated and fixed PCM5122 support

### DIFF
--- a/components/audio_board/Kconfig.projbuild
+++ b/components/audio_board/Kconfig.projbuild
@@ -273,6 +273,19 @@ menu "Audio Board"
 	                This is labeled "X(S)MT" on chip/boards
 	    endmenu
 
+	     menu "TI PCM51XX interface Configuration"
+	        depends on DAC_PCM51XX
+
+	        config PCM51XX_MUTE_PIN
+	            int "Master mute/unmute GPIO for PCM51XX"
+	            default 255
+	            help
+	                GPIO number to control mute/unmute pin (hardware mute).
+	                Set to 255 to disable hardware mute pin control.
+	                When enabled, this pin will be set HIGH on unmute and LOW on mute.
+	                This is in addition to the I2C register-based mute control.
+	    endmenu
+
 	    menu "MAX98357 interface Configuration"
 	        depends on DAC_MAX98357
 

--- a/components/custom_board/pcm51xx/include/pcm51xx.h
+++ b/components/custom_board/pcm51xx/include/pcm51xx.h
@@ -128,15 +128,30 @@ esp_err_t pcm51xx_set_mute(bool enable);
 esp_err_t pcm51xx_get_mute(bool *enabled);
 
 /**
- * @brief Set DAMP mode
+ * @brief Control codec mode
  *
- * @param value  PCM51XX_DAMP_MODE_BTL or PCM51XX_DAMP_MODE_PBTL
+ * @param mode codec mode
+ * @param ctrl_state control state
+ *
  * @return
- *     - ESP_FAIL Parameter error
- *     - ESP_OK   Success
- *
+ *     - ESP_OK
+ *     - ESP_FAIL
  */
-esp_err_t pcm51xx_set_damp_mode(int value);
+esp_err_t pcm51xx_ctrl(audio_hal_codec_mode_t mode,
+                       audio_hal_ctrl_t ctrl_state);
+
+/**
+ * @brief Configure codec interface
+ *
+ * @param mode codec mode
+ * @param iface I2S interface configuration
+ *
+ * @return
+ *     - ESP_OK
+ *     - ESP_FAIL
+ */
+esp_err_t pcm51xx_config_iface(audio_hal_codec_mode_t mode,
+                               audio_hal_codec_i2s_iface_t *iface);
 
 #ifdef __cplusplus
 }

--- a/components/custom_board/pcm51xx/include/pcm51xx_reg_cfg.h
+++ b/components/custom_board/pcm51xx/include/pcm51xx_reg_cfg.h
@@ -45,8 +45,8 @@ static const pcm51xx_cfg_reg_t pcm51xx_init_seq[] = {
     {0x02, 0x00},  // DISABLE STBY
     {0x0d, 0x10},  // BCK as SRC for PLL
     {0x25, 0x08},  // IGNORE MISSING MCLK
-    {0x3d, 0x55},  // DIGITAL VOLUME L
-    {0x3e, 0x55},  // DIGITAL VOLUME R
+    {0x3d, 0x30},  // DIGITAL VOLUME L
+    {0x3e, 0x30},  // DIGITAL VOLUME R
 };
 
 #ifdef __cplusplus

--- a/components/custom_board/pcm51xx/pcm51xx.c
+++ b/components/custom_board/pcm51xx/pcm51xx.c
@@ -31,13 +31,26 @@
 #include "esp_log.h"
 #include "i2c_bus.h"
 #include "pcm51xx_reg_cfg.h"
+#include "driver/gpio.h"
 
 static const char *TAG = "PCM51XX";
 
-#define PCM51XX_BASE_ADDR 0x98
-#define PCM51XX_RST_GPIO get_pa_enable_gpio()
-#define PCM51XX_VOLUME_MAX 255
+// Volume range in percentage
+#define PCM51XX_VOLUME_MAX 100
 #define PCM51XX_VOLUME_MIN 0
+
+// PCM51XX register values
+#define PCM51XX_REG_VAL_0DB    0x30  // 48 decimal = 0dB
+#define PCM51XX_REG_VAL_MUTE   0xFF  // 255 decimal = mute
+
+// GPIO mute pin configuration
+#ifdef CONFIG_PCM51XX_MUTE_PIN
+#define PCM51XX_MUTE_PIN CONFIG_PCM51XX_MUTE_PIN
+#else
+#define PCM51XX_MUTE_PIN 255
+#endif
+
+#define PCM51XX_MUTE_PIN_VALID(pin) ((pin) != 255)
 
 #define PCM51XX_ASSERT(a, format, b, ...) \
   if ((a) != 0) {                         \
@@ -50,7 +63,17 @@ esp_err_t pcm51xx_ctrl(audio_hal_codec_mode_t mode,
 esp_err_t pcm51xx_config_iface(audio_hal_codec_mode_t mode,
                                audio_hal_codec_i2s_iface_t *iface);
 static i2c_bus_handle_t i2c_handler;
-static int pcm51xx_addr;
+// CONFIG_DAC_I2C_ADDR is 7-bit address, but i2c_bus functions expect 8-bit (shifted) address
+static const int pcm51xx_addr = (CONFIG_DAC_I2C_ADDR << 1);
+
+// State tracking
+static struct {
+  int volume_percent;     // Current volume in percentage (0-100)
+  bool is_muted;          // Current mute state
+} pcm51xx_state = {
+  .volume_percent = 100,  // Default to 100%
+  .is_muted = true,       // Default to muted
+};
 
 /*
  * i2c default configuration
@@ -79,6 +102,7 @@ audio_hal_func_t AUDIO_CODEC_PCM51XX_DEFAULT_HANDLE = {
 
 static esp_err_t pcm51xx_transmit_registers(const pcm51xx_cfg_reg_t *conf_buf,
                                             int size) {
+  ESP_LOGD(TAG, "%s: size=%d", __func__, size);
   int i = 0;
   esp_err_t ret = ESP_OK;
   while (i < size) {
@@ -96,37 +120,39 @@ static esp_err_t pcm51xx_transmit_registers(const pcm51xx_cfg_reg_t *conf_buf,
 }
 
 esp_err_t pcm51xx_init(audio_hal_codec_config_t *codec_cfg) {
+  ESP_LOGD(TAG, "%s: codec_cfg=%p", __func__, codec_cfg);
   esp_err_t ret = ESP_OK;
-  // probably unnecessary...
-  /*
-ESP_LOGI(TAG, "Power ON CODEC with GPIO %d", PCM51XX_RST_GPIO);
-gpio_config_t io_conf;
-io_conf.pin_bit_mask = BIT64(PCM51XX_RST_GPIO);
-io_conf.mode = GPIO_MODE_OUTPUT;
-io_conf.intr_type = GPIO_INTR_DISABLE;
-gpio_config(&io_conf);
-gpio_set_level(PCM51XX_RST_GPIO, 0);
-vTaskDelay(20 / portTICK_PERIOD_MS);
-gpio_set_level(PCM51XX_RST_GPIO, 1);
-vTaskDelay(200 / portTICK_PERIOD_MS);
-  */
 
   ret = get_i2c_pins(I2C_NUM_0, &i2c_cfg);
+  ESP_LOGI(TAG, "PCM51XX I2C pins set: SDA=%d, SCL=%d", i2c_cfg.sda_io_num,
+           i2c_cfg.scl_io_num);
   i2c_handler = i2c_bus_create(I2C_NUM_0, &i2c_cfg);
   if (i2c_handler == NULL) {
     ESP_LOGW(TAG, "failed to create i2c bus handler\n");
     return ESP_FAIL;
   }
 
-  uint8_t data[] = {0, 0};
-  for (int i = 0; i < 4; i++) {
-    pcm51xx_addr = PCM51XX_BASE_ADDR + 2 * i;
-    ESP_LOGI(TAG, "Looking for a pcm51xx chip at address 0x%x", pcm51xx_addr);
-    ret = i2c_bus_write_data(i2c_handler, pcm51xx_addr, data, 0);
+  ESP_LOGI(TAG, "Using pcm51xx chip at address 0x%x", pcm51xx_addr);
+
+  // Initialize GPIO mute pin if configured
+  if (PCM51XX_MUTE_PIN_VALID(PCM51XX_MUTE_PIN)) {
+    gpio_config_t io_conf = {
+      .pin_bit_mask = (1ULL << PCM51XX_MUTE_PIN),
+      .mode = GPIO_MODE_OUTPUT,
+      .pull_up_en = GPIO_PULLUP_DISABLE,
+      .pull_down_en = GPIO_PULLDOWN_DISABLE,
+      .intr_type = GPIO_INTR_DISABLE,
+    };
+    ret = gpio_config(&io_conf);
     if (ret == ESP_OK) {
-      ESP_LOGI(TAG, "Found a pcm51xx chip at address 0x%x", pcm51xx_addr);
-      break;
+      // Initialize to muted state (LOW)
+      gpio_set_level(PCM51XX_MUTE_PIN, 0);
+      ESP_LOGI(TAG, "PCM51XX GPIO mute pin %d configured", PCM51XX_MUTE_PIN);
+    } else {
+      ESP_LOGW(TAG, "Failed to configure GPIO mute pin %d", PCM51XX_MUTE_PIN);
     }
+  } else {
+    ESP_LOGI(TAG, "PCM51XX GPIO mute pin disabled (using register control only)");
   }
 
   PCM51XX_ASSERT(ret, "Fail to detect pcm51xx PA", ESP_FAIL);
@@ -138,44 +164,76 @@ vTaskDelay(200 / portTICK_PERIOD_MS);
 }
 
 esp_err_t pcm51xx_set_volume(int vol) {
-  // vol is given as 1/2dB step with
-  // 255: -inf (mute)
-  // 254: -103dB
-  // 48:  0dB
-  // 0 (max): +24dB
+  ESP_LOGD(TAG, "%s: vol=%d%%", __func__, vol);
+  // vol is given as percentage (0-100%)
+  // Input range: 0% (min) to 100% (max/0dB)
+  // 
+  // PCM51XX register mapping (1/2dB steps):
+  // 0x30 (48 decimal):  0dB    <- 100%
+  // 0xFF (255):        -inf (mute) <- 0%
+  //
+  // Inverted mapping: higher percentage = higher register value (less attenuation)
 
-  if (vol < PCM51XX_VOLUME_MIN) {
-    vol = PCM51XX_VOLUME_MIN;
+  // Clamp input to valid range
+  if (vol < 0) {
+    vol = 0;
   }
-  if (vol > PCM51XX_VOLUME_MAX) {
-    vol = PCM51XX_VOLUME_MAX;
+  if (vol > 100) {
+    vol = 100;
   }
+
+  uint8_t register_value;
+  
+  if (vol == 0) {
+    // 0% = mute
+    register_value = 0xFF;
+  } else {
+    // Map 1-100% to register values 0xFE-0x30
+    // Linear mapping: 100% -> 0x30 (48), 1% -> 0xFE (254)
+    // Formula: reg_val = 0x30 + (100 - vol) * (0xFE - 0x30) / 99
+    //        = 48 + (100 - vol) * 206 / 99
+    register_value = 0x30 + ((100 - vol) * 206) / 99;
+  }
+
   uint8_t cmd[2] = {0, 0};
   esp_err_t ret = ESP_OK;
 
-  cmd[1] = vol;
+  cmd[1] = register_value;
 
   cmd[0] = PCM51XX_REG_VOL_L;
   ret = i2c_bus_write_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
   cmd[0] = PCM51XX_REG_VOL_R;
   ret |= i2c_bus_write_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
-  ESP_LOGW(TAG, "Volume set to 0x%x", cmd[1]);
+  
+  if (ret == ESP_OK) {
+    // Store the volume in state for later retrieval
+    pcm51xx_state.volume_percent = vol;
+  }
+  
+  ESP_LOGD(TAG, "Volume set to %d%% (register: 0x%02x)", vol, register_value);
   return ret;
 }
 
 esp_err_t pcm51xx_get_volume(int *value) {
-  /// FIXME: Got the digit volume is not right.
-  uint8_t cmd[2] = {PCM51XX_REG_VOL_L, 0x00};
-  esp_err_t ret =
-      i2c_bus_read_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
-  PCM51XX_ASSERT(ret, "Fail to get volume", ESP_FAIL);
-  ESP_LOGI(TAG, "Volume is %d", cmd[1]);
-  *value = cmd[1];
-  return ret;
+  ESP_LOGD(TAG, "%s: value=%p", __func__, value);
+  
+  if (value == NULL) {
+    ESP_LOGE(TAG, "Null pointer provided for volume value");
+    return ESP_FAIL;
+  }
+  
+  // Return the stored volume percentage
+  *value = pcm51xx_state.volume_percent;
+  ESP_LOGD(TAG, "Volume is %d%%", *value);
+  
+  return ESP_OK;
 }
 
 esp_err_t pcm51xx_set_mute(bool enable) {
+  ESP_LOGD(TAG, "%s: enable=%d", __func__, enable);
   esp_err_t ret = ESP_OK;
+  
+  // Control I2C register-based mute
   uint8_t cmd[2] = {PCM51XX_REG_MUTE, 0x00};
   ret |= i2c_bus_read_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
 
@@ -186,34 +244,53 @@ esp_err_t pcm51xx_set_mute(bool enable) {
   }
   ret |= i2c_bus_write_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
 
+  // Control GPIO mute pin if configured
+  if (PCM51XX_MUTE_PIN_VALID(PCM51XX_MUTE_PIN)) {
+    // Set pin HIGH for unmute, LOW for mute
+    gpio_set_level(PCM51XX_MUTE_PIN, enable ? 0 : 1);
+    ESP_LOGD(TAG, "GPIO mute pin %d set to %d", PCM51XX_MUTE_PIN, enable ? 0 : 1);
+  }
+
   PCM51XX_ASSERT(ret, "Fail to set mute", ESP_FAIL);
+  
+  // Store mute state
+  pcm51xx_state.is_muted = enable;
+  
+  ESP_LOGI(TAG, "Mute %s (register + GPIO)", enable ? "enabled" : "disabled");
   return ret;
 }
 
 esp_err_t pcm51xx_get_mute(bool *enabled) {
-  esp_err_t ret = ESP_OK;
-  uint8_t cmd[2] = {PCM51XX_REG_MUTE, 0x00};
-  ret |= i2c_bus_read_bytes(i2c_handler, pcm51xx_addr, &cmd[0], 1, &cmd[1], 1);
-
-  PCM51XX_ASSERT(ret, "Fail to get mute", ESP_FAIL);
-  *enabled = (bool)(cmd[1] & 0x11);
+  ESP_LOGD(TAG, "%s: enabled=%p", __func__, enabled);
+  
+  if (enabled == NULL) {
+    ESP_LOGE(TAG, "Null pointer provided for mute value");
+    return ESP_FAIL;
+  }
+  
+  // Return the stored mute state
+  *enabled = pcm51xx_state.is_muted;
   ESP_LOGI(TAG, "Get mute value: %s", *enabled ? "muted" : "unmuted");
-  return ret;
+  
+  return ESP_OK;
 }
 
 esp_err_t pcm51xx_deinit(void) {
+  ESP_LOGD(TAG, "%s", __func__);
   // TODO
   return ESP_OK;
 }
 
 esp_err_t pcm51xx_ctrl(audio_hal_codec_mode_t mode,
                        audio_hal_ctrl_t ctrl_state) {
+  ESP_LOGD(TAG, "%s: mode=%d, ctrl_state=%d", __func__, mode, ctrl_state);
   // TODO
   return ESP_OK;
 }
 
 esp_err_t pcm51xx_config_iface(audio_hal_codec_mode_t mode,
                                audio_hal_codec_i2s_iface_t *iface) {
+  ESP_LOGD(TAG, "%s: mode=%d, iface=%p", __func__, mode, iface);
   // TODO
   return ESP_OK;
 }


### PR DESCRIPTION
Fixed I2C communication
Using correct address as cpecified in menuconfig
Validated init sequence
Fixed digital volume (correct mapping of 1-100% range), 
and mute (both software and pin mute)
Added optional mute pin control (XSMT pin of DAC)

All tested on [HiFi-ESP32-Plus](https://www.tindie.com/products/sonocotta/hifi-esp32-plus/) board and working really well (audio quality is awesome on this DAC!)

#166 
also [#4](https://github.com/sonocotta/esparagus-snapclient/issues/4)