### PR TITLE
fix: Reset timing filters during hard resync to prevent infinite loop

### DIFF
--- a/components/lightsnapcast/player.c
+++ b/components/lightsnapcast/player.c
@@ -1573,6 +1573,8 @@ static void player_task(void *pvParameters) {
 
           my_i2s_channel_disable(tx_chan);
 
+          initialSync = 0;
+
           continue;
         }
       }


### PR DESCRIPTION
When a hard resync was triggered (HARD 1 or HARD 2), the TimeFilter and median filters retained stale/corrupt values. This caused the next sync attempt to calculate garbage latency values (e.g. 17+ days), immediately re-triggering another hard resync in an infinite loop.

Fix: Call reset_latency_buffer() and MEDIANFILTER_Init() for both short and mini filters during both hard resync paths. This ensures clean state for the next sync attempt.

Symptoms fixed:
- Infinite RESYNCING HARD 1/2 spam
- Corrupted latency values (1469934083866us)
- TAS5805M clock faults from repeated I2S stops
- Audio dropout not recovering