### PR TITLE
fix: Enable I2S DMA auto_clear to silence audio on pause

### DIFF
--- a/components/lightsnapcast/player.c
+++ b/components/lightsnapcast/player.c
@@ -288,7 +288,7 @@ static esp_err_t player_setup_i2s(snapcastSetting_t *setting) {
       .role = I2S_ROLE_MASTER,
       .dma_desc_num = i2sDmaBufCnt,
       .dma_frame_num = i2sDmaBufMaxLen,
-      .auto_clear = false,
+      .auto_clear = true,
   };
   ESP_ERROR_CHECK(i2s_new_channel(&tx_chan_cfg, &tx_chan, NULL));
 


### PR DESCRIPTION
When the server pauses playback, the player was repeating the last audio block for ~2 seconds causing unpleasant noise. This was because auto_clear=false caused the DMA to loop the last buffer during underrun.

Setting auto_clear=true fills the DMA buffer with zeros (silence) when there's no new data, providing clean audio cutoff on pause.