### PR TITLE
Improvements to refactor parser

### DIFF
--- a/components/lightsnapcast/include/snapcast_protocol_parser.h
+++ b/components/lightsnapcast/include/snapcast_protocol_parser.h
@@ -32,7 +32,6 @@ parser_return_state_t parse_base_message(snapcast_protocol_parser_t* parser,
 
 parser_return_state_t parse_wire_chunk_message(snapcast_protocol_parser_t* parser,
                                                base_message_t* base_message_rx,
-                                               bool received_codec_header,
                                                codec_type_t codec,
                                                pcm_chunk_message_t** pcmData,
                                                wire_chunk_message_t* wire_chnk,

--- a/components/lightsnapcast/include/snapcast_protocol_parser.h
+++ b/components/lightsnapcast/include/snapcast_protocol_parser.h
@@ -51,7 +51,7 @@ parser_return_state_t parse_time_message(snapcast_protocol_parser_t* parser,
                                          base_message_t* base_message_rx,
                                          time_message_t* time_message_rx);
 
-parser_return_state_t parse_unknown_message(snapcast_protocol_parser_t* parser,
-                                            base_message_t* base_message_rx);
+parser_return_state_t parser_skip_typed_message(snapcast_protocol_parser_t* parser,
+                                                base_message_t* base_message_rx);
 
 #endif  // __SNAPCAST_PROTOCOL_PARSER_H__

--- a/components/lightsnapcast/include/snapcast_protocol_parser.h
+++ b/components/lightsnapcast/include/snapcast_protocol_parser.h
@@ -24,7 +24,6 @@ typedef struct {
 typedef enum {
   PARSER_COMPLETE = 0,
   PARSER_INCOMPLETE,
-  PARSER_CRITICAL_ERROR,
   PARSER_CONNECTION_ERROR,
 } parser_return_state_t;
 

--- a/components/lightsnapcast/include/snapcast_protocol_parser.h
+++ b/components/lightsnapcast/include/snapcast_protocol_parser.h
@@ -22,9 +22,8 @@ typedef struct {
 } snapcast_protocol_parser_t;
 
 typedef enum {
-  PARSER_COMPLETE = 0,
-  PARSER_INCOMPLETE,
-  PARSER_CONNECTION_ERROR,
+  PARSER_OK = 0,
+  PARSER_RESTART_CONNECTION,
 } parser_return_state_t;
 
 parser_return_state_t parse_base_message(snapcast_protocol_parser_t* parser,

--- a/components/lightsnapcast/snapcast_protocol_parser.c
+++ b/components/lightsnapcast/snapcast_protocol_parser.c
@@ -173,7 +173,8 @@ parser_return_state_t parse_wire_chunk_message(snapcast_protocol_parser_t* parse
       }
       default: {
         ESP_LOGE(TAG, "Decoder (1) not supported");
-        return PARSER_CRITICAL_ERROR;
+        // critical error
+        esp_restart();
       }
     }
   }
@@ -205,7 +206,8 @@ parser_return_state_t parse_codec_header_message(
              "opus, flac or pcm in "
              "/etc/snapserver.conf on "
              "server");
-    return PARSER_CRITICAL_ERROR;
+    // critical error
+    esp_restart();
   }
   READ_DATA(parser, codecString, codecStringLen);
 
@@ -230,7 +232,8 @@ parser_return_state_t parse_codec_header_message(
              "/etc/snapserver.conf on "
              "server");
 
-    return PARSER_CRITICAL_ERROR;
+    // critical error
+    esp_restart();
   }
 
   //
@@ -243,7 +246,8 @@ parser_return_state_t parse_codec_header_message(
              "couldn't get memory "
              "for codec payload");
 
-    return PARSER_CRITICAL_ERROR;
+    // critical error
+    esp_restart();
   }
 
   READ_DATA(parser, *codecPayload, *codecPayloadLen);
@@ -268,7 +272,8 @@ parser_return_state_t parse_sever_settings_message(
     ESP_LOGE(TAG,
              "couldn't get memory for "
              "server settings string");
-    return PARSER_CRITICAL_ERROR;
+    // critical error
+    esp_restart();
   }
 
   size_t tmpSize = base_message_rx->size - 4;
@@ -295,7 +300,8 @@ parser_return_state_t parse_sever_settings_message(
              "Failed to read server "
              "settings: %d",
              deserialization_result);
-    return PARSER_CRITICAL_ERROR;
+    // critical error
+    esp_restart();
   }
 
   return PARSER_COMPLETE;  // do callback

--- a/components/lightsnapcast/snapcast_protocol_parser.c
+++ b/components/lightsnapcast/snapcast_protocol_parser.c
@@ -7,7 +7,7 @@
   do { \
     char _byte; \
     if ((parser)->get_byte_function((parser)->get_byte_context, &_byte) != 0) { \
-      return PARSER_CONNECTION_ERROR; \
+      return PARSER_RESTART_CONNECTION; \
     } \
     (dest) = _byte; \
   } while(0)
@@ -17,7 +17,7 @@
     char _bytes[2]; \
     if ((parser)->get_byte_function((parser)->get_byte_context, &_bytes[0]) != 0 || \
         (parser)->get_byte_function((parser)->get_byte_context, &_bytes[1]) != 0) { \
-      return PARSER_CONNECTION_ERROR; \
+      return PARSER_RESTART_CONNECTION; \
     } \
     (dest) = (_bytes[0] & 0xFF) | ((_bytes[1] & 0xFF) << 8); \
   } while(0)
@@ -27,7 +27,7 @@
     char _bytes[4]; \
     for (int _i = 0; _i < 4; _i++) { \
       if ((parser)->get_byte_function((parser)->get_byte_context, &_bytes[_i]) != 0) { \
-        return PARSER_CONNECTION_ERROR; \
+        return PARSER_RESTART_CONNECTION; \
       } \
     } \
     (dest) = (_bytes[0] & 0xFF) | ((_bytes[1] & 0xFF) << 8) | \
@@ -44,7 +44,7 @@
   do { \
     for (uint32_t _i = 0; _i < (len); _i++) { \
       if ((parser)->get_byte_function((parser)->get_byte_context, &(dest)[_i]) != 0) { \
-        return PARSER_CONNECTION_ERROR; \
+        return PARSER_RESTART_CONNECTION; \
       } \
     } \
   } while(0)
@@ -54,7 +54,7 @@
     for (uint32_t _i = 0; _i < (len); _i++) { \
       if ((parser)->get_byte_function((parser)->get_byte_context, &(dest)[_i]) != 0) { \
         cleanup; \
-        return PARSER_CONNECTION_ERROR; \
+        return PARSER_RESTART_CONNECTION; \
       } \
     } \
   } while(0)
@@ -70,7 +70,7 @@ parser_return_state_t parse_base_message(snapcast_protocol_parser_t* parser,
   READ_TIMESTAMP(parser, base_message_rx->received);
   READ_UINT32_LE(parser, base_message_rx->size);
 
-  return PARSER_COMPLETE;
+  return PARSER_OK;
 }
 
 
@@ -180,7 +180,7 @@ parser_return_state_t parse_wire_chunk_message(snapcast_protocol_parser_t* parse
     }
   }
 
-  return PARSER_COMPLETE;
+  return PARSER_OK;
 }
 
 parser_return_state_t parse_codec_header_message(
@@ -204,7 +204,7 @@ parser_return_state_t parse_codec_header_message(
              "/etc/snapserver.conf on "
              "server");
     // restart connection
-    return PARSER_CONNECTION_ERROR;
+    return PARSER_RESTART_CONNECTION;
   }
   READ_DATA(parser, codecString, codecStringLen);
 
@@ -230,7 +230,7 @@ parser_return_state_t parse_codec_header_message(
              "server");
 
     // restart connection
-    return PARSER_CONNECTION_ERROR;
+    return PARSER_RESTART_CONNECTION;
   }
 
   //
@@ -251,7 +251,7 @@ parser_return_state_t parse_codec_header_message(
 
   *received_codec_header = true;
 
-  return PARSER_COMPLETE;
+  return PARSER_OK;
 }
 
 parser_return_state_t parse_sever_settings_message(
@@ -301,7 +301,7 @@ parser_return_state_t parse_sever_settings_message(
     esp_restart();
   }
 
-  return PARSER_COMPLETE;  // do callback
+  return PARSER_OK;  // do callback
 
 }
 
@@ -315,11 +315,11 @@ parser_return_state_t parse_time_message(snapcast_protocol_parser_t* parser,
     ESP_LOGE(TAG,
              "error time message, this shouldn't happen! %d %ld",
              8, base_message_rx->size);
-    return PARSER_INCOMPLETE;  // use this return value as "ignore"
+    return PARSER_RESTART_CONNECTION;
   }
 
   // ESP_LOGI(TAG, "done time message");
-  return PARSER_COMPLETE;  // do callback
+  return PARSER_OK;  // do callback
 }
 
 parser_return_state_t parser_skip_typed_message(snapcast_protocol_parser_t* parser,
@@ -332,5 +332,5 @@ parser_return_state_t parser_skip_typed_message(snapcast_protocol_parser_t* pars
 
   ESP_LOGI(TAG, "done skipping typed message %d", base_message_rx->type);
 
-  return PARSER_COMPLETE;
+  return PARSER_OK;
 }

--- a/components/lightsnapcast/snapcast_protocol_parser.c
+++ b/components/lightsnapcast/snapcast_protocol_parser.c
@@ -77,7 +77,6 @@ parser_return_state_t parse_base_message(snapcast_protocol_parser_t* parser,
 
 parser_return_state_t parse_wire_chunk_message(snapcast_protocol_parser_t* parser,
                                                base_message_t* base_message_rx,
-                                               bool received_codec_header,
                                                codec_type_t codec,
                                                pcm_chunk_message_t** pcmData,
                                                wire_chunk_message_t* wire_chnk,

--- a/components/lightsnapcast/snapcast_protocol_parser.c
+++ b/components/lightsnapcast/snapcast_protocol_parser.c
@@ -172,7 +172,10 @@ parser_return_state_t parse_wire_chunk_message(snapcast_protocol_parser_t* parse
         break;
       }
       default: {
-        ESP_LOGE(TAG, "Decoder (1) not supported");
+        ESP_LOGE(TAG, "Decoder (1) not supported. This should never happen!");
+        // The case NONE should never happen, because we only set received_codec_header to true,
+        // if we got a supported codec header message (cf. parse_codec_header_message).
+        // So if we get here, something went very wrong.
         // critical error
         esp_restart();
       }
@@ -206,8 +209,8 @@ parser_return_state_t parse_codec_header_message(
              "opus, flac or pcm in "
              "/etc/snapserver.conf on "
              "server");
-    // critical error
-    esp_restart();
+    // restart connection
+    return PARSER_CONNECTION_ERROR;
   }
   READ_DATA(parser, codecString, codecStringLen);
 
@@ -232,8 +235,8 @@ parser_return_state_t parse_codec_header_message(
              "/etc/snapserver.conf on "
              "server");
 
-    // critical error
-    esp_restart();
+    // restart connection
+    return PARSER_CONNECTION_ERROR;
   }
 
   //
@@ -300,7 +303,7 @@ parser_return_state_t parse_sever_settings_message(
              "Failed to read server "
              "settings: %d",
              deserialization_result);
-    // critical error
+    // critical error. A failed deserialization could potentially be a memory issue.
     esp_restart();
   }
 

--- a/components/lightsnapcast/snapcast_protocol_parser.c
+++ b/components/lightsnapcast/snapcast_protocol_parser.c
@@ -1,6 +1,8 @@
 #include "snapcast_protocol_parser.h"
 
 #include "esp_log.h"
+#include "freertos/task.h" // for vTaskDelay
+#include <string.h>
 
 // MACROS for reading from connection
 #define READ_BYTE(parser, dest) \
@@ -197,7 +199,7 @@ parser_return_state_t parse_codec_header_message(
   if (codecStringLen + 1 > sizeof(codecString)) {
     READ_DATA(parser, codecString, sizeof(codecString)-1);
     codecString[sizeof(codecString)-1] = 0; // null terminate
-    ESP_LOGE(TAG, "Codec : %s... not supported %lu", codecStringLen);
+    ESP_LOGE(TAG, "Codec : %s... not supported", codecString);
     ESP_LOGI(TAG,
              "Change encoder codec to "
              "opus, flac or pcm in "

--- a/components/lightsnapcast/snapcast_protocol_parser.c
+++ b/components/lightsnapcast/snapcast_protocol_parser.c
@@ -104,89 +104,84 @@ parser_return_state_t parse_wire_chunk_message(snapcast_protocol_parser_t* parse
   int32_t payloadDataShift = 0;
   size_t tmp_size = base_message_rx->size - 12;
 
-  if (received_codec_header == true) {
-    switch (codec) {
-      case OPUS:
-      case FLAC: {
-        READ_DATA(parser, (char*)decoderChunk->inData, tmp_size);
-        payloadOffset += tmp_size;
-        decoderChunk->outData = NULL;
-        decoderChunk->type = SNAPCAST_MESSAGE_WIRE_CHUNK;
+  // if (received_codec_header == true) { //already checked in caller, so should always be true
+  switch (codec) {
+    case OPUS:
+    case FLAC: {
+      READ_DATA(parser, (char*)decoderChunk->inData, tmp_size);
+      payloadOffset += tmp_size;
+      decoderChunk->outData = NULL;
+      decoderChunk->type = SNAPCAST_MESSAGE_WIRE_CHUNK;
 
-        break;
+      break;
+    }
+
+    case PCM: {
+      size_t _tmp = tmp_size;
+
+      if (*pcmData == NULL) {
+        if (allocate_pcm_chunk_memory(pcmData, wire_chnk->size) < 0) {
+          *pcmData = NULL;
+        }
+
+        tmpData = 0;
+        payloadDataShift = 3;
+        payloadOffset = 0;
       }
 
-      case PCM: {
-        size_t _tmp = tmp_size;
+      while (_tmp--) {
+        char tmp_val;
+        READ_BYTE(parser, tmp_val);
+        tmpData |= ((uint32_t)tmp_val << (8 * payloadDataShift));
 
-        if (*pcmData == NULL) {
-          if (allocate_pcm_chunk_memory(pcmData, wire_chnk->size) < 0) {
-            *pcmData = NULL;
+        payloadDataShift--;
+        if (payloadDataShift < 0) {
+          payloadDataShift = 3;
+
+          if ((*pcmData) && ((*pcmData)->fragment->payload)) {
+            volatile uint32_t* sample;
+            uint8_t dummy1;
+            uint32_t dummy2 = 0;
+
+            // TODO: find a more
+            // clever way to do this,
+            // best would be to
+            // actually store it the
+            // right way in the first
+            // place
+            dummy1 = tmpData >> 24;
+            dummy2 |= (uint32_t)dummy1 << 16;
+            dummy1 = tmpData >> 16;
+            dummy2 |= (uint32_t)dummy1 << 24;
+            dummy1 = tmpData >> 8;
+            dummy2 |= (uint32_t)dummy1 << 0;
+            dummy1 = tmpData >> 0;
+            dummy2 |= (uint32_t)dummy1 << 8;
+            tmpData = dummy2;
+
+            sample = (volatile uint32_t *)(&((*pcmData)->fragment->payload[payloadOffset]));
+            *sample = (volatile uint32_t)tmpData;
+
+            payloadOffset += 4;
           }
 
           tmpData = 0;
-          payloadDataShift = 3;
-          payloadOffset = 0;
         }
-
-        while (_tmp--) {
-          char tmp_val;
-          READ_BYTE(parser, tmp_val);
-          tmpData |= ((uint32_t)tmp_val << (8 * payloadDataShift));
-
-          payloadDataShift--;
-          if (payloadDataShift < 0) {
-            payloadDataShift = 3;
-
-            if ((*pcmData) && ((*pcmData)->fragment->payload)) {
-              volatile uint32_t* sample;
-              uint8_t dummy1;
-              uint32_t dummy2 = 0;
-
-              // TODO: find a more
-              // clever way to do this,
-              // best would be to
-              // actually store it the
-              // right way in the first
-              // place
-              dummy1 = tmpData >> 24;
-              dummy2 |= (uint32_t)dummy1 << 16;
-              dummy1 = tmpData >> 16;
-              dummy2 |= (uint32_t)dummy1 << 24;
-              dummy1 = tmpData >> 8;
-              dummy2 |= (uint32_t)dummy1 << 0;
-              dummy1 = tmpData >> 0;
-              dummy2 |= (uint32_t)dummy1 << 8;
-              tmpData = dummy2;
-
-              sample = (volatile uint32_t *)(&((*pcmData)->fragment->payload[payloadOffset]));
-              *sample = (volatile uint32_t)tmpData;
-
-              payloadOffset += 4;
-            }
-
-            tmpData = 0;
-          }
-        }
-
-        break;
       }
-      default: {
-        ESP_LOGE(TAG, "Decoder (1) not supported. This should never happen!");
-        // The case NONE should never happen, because we only set received_codec_header to true,
-        // if we got a supported codec header message (cf. parse_codec_header_message).
-        // So if we get here, something went very wrong.
-        // critical error
-        esp_restart();
-      }
+
+      break;
+    }
+    default: {
+      ESP_LOGE(TAG, "Decoder (1) not supported. This should never happen!");
+      // The case NONE should never happen, because we only set received_codec_header to true,
+      // if we got a supported codec header message (cf. parse_codec_header_message).
+      // So if we get here, something went very wrong.
+      // critical error
+      esp_restart();
     }
   }
 
-  if (received_codec_header == true) {
-    return PARSER_COMPLETE;
-  } else {
-    return PARSER_INCOMPLETE;  // TODO: right return value?
-  }
+  return PARSER_COMPLETE;
 }
 
 parser_return_state_t parse_codec_header_message(
@@ -328,7 +323,7 @@ parser_return_state_t parse_time_message(snapcast_protocol_parser_t* parser,
   return PARSER_COMPLETE;  // do callback
 }
 
-parser_return_state_t parse_unknown_message(snapcast_protocol_parser_t* parser,
+parser_return_state_t parser_skip_typed_message(snapcast_protocol_parser_t* parser,
                                             base_message_t* base_message_rx) {
   // For unknown messages, we need to consume all remaining bytes
   char dummy_byte;
@@ -336,7 +331,7 @@ parser_return_state_t parse_unknown_message(snapcast_protocol_parser_t* parser,
     READ_BYTE(parser, dummy_byte);
   }
 
-  ESP_LOGI(TAG, "done unknown typed message %d", base_message_rx->type);
+  ESP_LOGI(TAG, "done skipping typed message %d", base_message_rx->type);
 
   return PARSER_COMPLETE;
 }

--- a/main/connection_handler.c
+++ b/main/connection_handler.c
@@ -328,7 +328,7 @@ static int fill_buffer(bool* first_netbuf_processed, int* rc1,
 
     *rc1 = netbuf_data(firstNetBuf, (void**)start, len);
     if (*rc1 == ERR_OK) {
-      ESP_LOGD(TAG, "netconn rx, data len: %d, %d", len,
+      ESP_LOGD(TAG, "netconn rx, data len: %d, %d", *len,
                netbuf_len(firstNetBuf));
       return 0;
     } else {

--- a/main/main.c
+++ b/main/main.c
@@ -1010,8 +1010,17 @@ int process_data(snapcast_protocol_parser_t *parser,
 
   switch (base_message_rx.type) {
     case SNAPCAST_MESSAGE_WIRE_CHUNK: {
-      wire_chunk_message_t wire_chnk = {
-          {0, 0}, 0, NULL};  // is wire_chnk.payload ever used?
+      wire_chunk_message_t wire_chnk = {{0, 0}, 0, NULL};  // is wire_chnk.payload ever used?
+
+      // skip this wires chunk message if codec header message was not received yet!
+      if (*received_codec_header == false) {
+        if (parser_skip_typed_message(parser, &base_message_rx) ==
+            PARSER_CONNECTION_ERROR) {
+          return -1;
+        }
+        break;
+      }
+
       switch (parse_wire_chunk_message(parser, &base_message_rx,
                                        *received_codec_header, *codec, pcmData,
                                        &wire_chnk, &decoderChunk)) {
@@ -1095,7 +1104,7 @@ int process_data(snapcast_protocol_parser_t *parser,
     }
 
     default: {
-      if (parse_unknown_message(parser, &base_message_rx) ==
+      if (parser_skip_typed_message(parser, &base_message_rx) ==
           PARSER_CONNECTION_ERROR) {
         return -1;
       }

--- a/main/main.c
+++ b/main/main.c
@@ -999,14 +999,13 @@ int process_data(snapcast_protocol_parser_t *parser,
                  pcm_chunk_message_t **pcmData) {
   base_message_t base_message_rx;
 
-  if (parse_base_message(parser, &base_message_rx) == PARSER_COMPLETE) {
-    time_sync_data->now = esp_timer_get_time();
-    base_message_rx.received.sec = time_sync_data->now / 1000000;
-    base_message_rx.received.usec =
-        time_sync_data->now - base_message_rx.received.sec * 1000000;
-  } else {  // PARSER_CONNECTION_ERROR (only these two cases for base message)
+  if (parse_base_message(parser, &base_message_rx) != PARSER_OK) {
     return -1;  // restart connection
   }
+  time_sync_data->now = esp_timer_get_time();
+  base_message_rx.received.sec = time_sync_data->now / 1000000;
+  base_message_rx.received.usec =
+      time_sync_data->now - base_message_rx.received.sec * 1000000;
 
   switch (base_message_rx.type) {
     case SNAPCAST_MESSAGE_WIRE_CHUNK: {
@@ -1014,50 +1013,27 @@ int process_data(snapcast_protocol_parser_t *parser,
 
       // skip this wires chunk message if codec header message was not received yet!
       if (*received_codec_header == false) {
-        if (parser_skip_typed_message(parser, &base_message_rx) ==
-            PARSER_CONNECTION_ERROR) {
+        if (parser_skip_typed_message(parser, &base_message_rx) != PARSER_OK) {
           return -1;
         }
-        break;
+        return 0;
       }
 
-      switch (parse_wire_chunk_message(parser, &base_message_rx,
-                                       *codec, pcmData, &wire_chnk, &decoderChunk)) {
-        case PARSER_COMPLETE: {
-          handle_chunk_message(*codec, scSet, pcmData, &wire_chnk);
-          break;
-        }
-        case PARSER_INCOMPLETE: {
-          // need more data
-          return 0;
-        }
-        case PARSER_CONNECTION_ERROR: {
-          return -1;
-        }
+      if (parse_wire_chunk_message(parser, &base_message_rx, *codec, pcmData, &wire_chnk, &decoderChunk) != PARSER_OK) {
+        return -1;
       }
-      break;
+      handle_chunk_message(*codec, scSet, pcmData, &wire_chnk);
+      return 0;
     }
 
     case SNAPCAST_MESSAGE_CODEC_HEADER: {
       char *codecPayload = NULL;
       uint32_t codecPayloadLen = 0;
       int return_value = 0;
-      switch (parse_codec_header_message(parser, received_codec_header, codec,
-                                         &codecPayload, &codecPayloadLen)) {
-        case PARSER_COMPLETE: {
-          codec_header_received(codecPayload, codecPayloadLen, *codec,
-                                    scSet, time_sync_data);
-          break;
-        }
-        case PARSER_CONNECTION_ERROR: {
-          return_value = -1;
-          break;
-        }
-        case PARSER_INCOMPLETE: {
-          // should not happen
-          // need more data
-          break;
-        }
+      if (parse_codec_header_message(parser, received_codec_header, codec, &codecPayload, &codecPayloadLen) != PARSER_OK) {
+        return_value = -1;
+      } else {
+        codec_header_received(codecPayload, codecPayloadLen, *codec, scSet, time_sync_data);
       }
 
       // in all cases: free Payload
@@ -1070,47 +1046,30 @@ int process_data(snapcast_protocol_parser_t *parser,
 
     case SNAPCAST_MESSAGE_SERVER_SETTINGS: {
       server_settings_message_t server_settings_message;
-      parser_return_state_t result = parse_sever_settings_message(
-          parser, &base_message_rx, &server_settings_message);
-      switch (result) {
-        case PARSER_COMPLETE: {
-          server_settings_msg_received(&server_settings_message, scSet);
-          break;
-        }
-        case PARSER_CONNECTION_ERROR: {
-          return -1;
-        }
-        case PARSER_INCOMPLETE: {
-          // should not happen
-          // need more data
-          break;
-        }
+      if (parse_sever_settings_message(parser, &base_message_rx, &server_settings_message) != PARSER_OK) {
+        return -1;
       }
-      break;
+      server_settings_msg_received(&server_settings_message, scSet);
+      return 0;
     }
 
     case SNAPCAST_MESSAGE_TIME: {
       time_message_t time_message_rx;
-      parser_return_state_t result =
-          parse_time_message(parser, &base_message_rx, &time_message_rx);
-      if (result == PARSER_COMPLETE) {
-        time_sync_msg_received(&base_message_rx, &time_message_rx,
-                               time_sync_data, *received_codec_header);
-      } else if (result == PARSER_CONNECTION_ERROR) {
+      if (parse_time_message(parser, &base_message_rx, &time_message_rx) != PARSER_OK) {
         return -1;
-      }  // could also be "incomplete", i.e. ignore content
-      break;
+      }
+      time_sync_msg_received(&base_message_rx, &time_message_rx, time_sync_data, *received_codec_header);
+      return 0;
     }
 
     default: {
-      if (parser_skip_typed_message(parser, &base_message_rx) ==
-          PARSER_CONNECTION_ERROR) {
+      if (parser_skip_typed_message(parser, &base_message_rx) != PARSER_OK) {
         return -1;
       }
-      break;
+      return 0;
     }
   }
-
+  // should never reach this
   return 0;
 }
 

--- a/main/main.c
+++ b/main/main.c
@@ -545,7 +545,7 @@ void audio_set_volume(int volume) {
 /**
  *
  */
-int server_settings_msg_received(
+void server_settings_msg_received(
     server_settings_message_t *server_settings_message,
     snapcastSetting_t *scSet) {
   // log mute state, buffer, latency
@@ -587,17 +587,17 @@ int server_settings_msg_received(
              "Failed to notify sync task. "
              "Did you init player?");
 
-    return -1;  // fatal, this triggers return from http_get_task
+    // critical error
+    esp_restart();
   }
-  return 0;
 }
 
 /**
  *
  */
-int codec_header_received(char *codecPayload, uint32_t codecPayloadLen,
-                          codec_type_t codec, snapcastSetting_t *scSet,
-                          time_sync_data_t *time_sync_data) {
+void codec_header_received(char *codecPayload, uint32_t codecPayloadLen,
+                           codec_type_t codec, snapcastSetting_t *scSet,
+                           time_sync_data_t *time_sync_data) {
   // first ensure everything is set up
   // correctly and resources are
   // available
@@ -634,7 +634,8 @@ int codec_header_received(char *codecPayload, uint32_t codecPayloadLen,
     opusDecoder = opus_decoder_create(scSet->sr, scSet->ch, &error);
     if (error != 0) {
       ESP_LOGI(TAG, "Failed to init opus coder");
-      return -1;
+      //critical error
+      esp_restart();
     }
 
     ESP_LOGI(TAG, "Initialized opus Decoder: %d", error);
@@ -651,7 +652,8 @@ int codec_header_received(char *codecPayload, uint32_t codecPayloadLen,
     flacDecoder = FLAC__stream_decoder_new();
     if (flacDecoder == NULL) {
       ESP_LOGE(TAG, "Failed to init flac decoder");
-      return -1;
+      //critical error
+      esp_restart();
     }
 
     FLAC__StreamDecoderInitStatus init_status =
@@ -662,7 +664,8 @@ int codec_header_received(char *codecPayload, uint32_t codecPayloadLen,
       ESP_LOGE(TAG, "ERROR: initializing decoder: %s\n",
                FLAC__StreamDecoderInitStatusString[init_status]);
 
-      return -1;
+      //critical error
+      esp_restart();
     }
 
     FLAC__stream_decoder_process_until_end_of_metadata(flacDecoder);
@@ -691,7 +694,8 @@ int codec_header_received(char *codecPayload, uint32_t codecPayloadLen,
              "shouldn't get here after "
              "codec string was detected");
 
-    return -1;
+    //critical error
+    esp_restart();
   }
 
   if (player_send_snapcast_setting(scSet) != pdPASS) {
@@ -699,7 +703,8 @@ int codec_header_received(char *codecPayload, uint32_t codecPayloadLen,
              "Failed to notify sync task. "
              "Did you init player?");
 
-    return -1;
+    //critical error
+    esp_restart();
   }
 
   // ESP_LOGI(TAG, "done codec header msg");
@@ -709,15 +714,14 @@ int codec_header_received(char *codecPayload, uint32_t codecPayloadLen,
   //   esp_timer_start_periodic(time_sync_data->timeSyncMessageTimer,
   //                            time_sync_data->timeout);
   // }
-  return 0;
 }
 
 /**
  *
  */
-int handle_chunk_message(codec_type_t codec, snapcastSetting_t *scSet,
-                         pcm_chunk_message_t **pcmData,
-                         wire_chunk_message_t *wire_chnk) {
+void handle_chunk_message(codec_type_t codec, snapcastSetting_t *scSet,
+                          pcm_chunk_message_t **pcmData,
+                          wire_chunk_message_t *wire_chnk) {
   switch (codec) {
     case OPUS: {
       int frame_size = -1;
@@ -813,7 +817,8 @@ int handle_chunk_message(codec_type_t codec, snapcastSetting_t *scSet,
                  "codec. Did you "
                  "init player?");
 
-        return -1;
+        // critical error
+        esp_restart();
       }
 
       break;
@@ -919,7 +924,8 @@ int handle_chunk_message(codec_type_t codec, snapcastSetting_t *scSet,
                  "codec. Did you "
                  "init player?");
 
-        return -1;
+        // critical error
+        esp_restart();
       }
 
       break;
@@ -950,7 +956,8 @@ int handle_chunk_message(codec_type_t codec, snapcastSetting_t *scSet,
                  "codec. Did you "
                  "init player?");
 
-        return -1;
+        // critical error
+        esp_restart();
       }
 
 #if CONFIG_USE_DSP_PROCESSOR
@@ -974,18 +981,17 @@ int handle_chunk_message(codec_type_t codec, snapcastSetting_t *scSet,
                "Decoder (2) not "
                "supported");
 
-      return -1;
+      // critical error
+      esp_restart();
 
       break;
     }
   }
-  return 0;
 }
 
 /*
  * returns:
  * 0 if a message was (partially) processed sucessfully
- * -1 if a critial error occured
  * -2 if network needs restart
  */
 int process_data(snapcast_protocol_parser_t *parser,
@@ -1011,13 +1017,8 @@ int process_data(snapcast_protocol_parser_t *parser,
                                        *received_codec_header, *codec, pcmData,
                                        &wire_chnk, &decoderChunk)) {
         case PARSER_COMPLETE: {
-          if (handle_chunk_message(*codec, scSet, pcmData, &wire_chnk) != 0) {
-            return -1;
-          }
+          handle_chunk_message(*codec, scSet, pcmData, &wire_chnk);
           break;
-        }
-        case PARSER_CRITICAL_ERROR: {
-          return -1;
         }
         case PARSER_INCOMPLETE: {
           // need more data
@@ -1037,14 +1038,8 @@ int process_data(snapcast_protocol_parser_t *parser,
       switch (parse_codec_header_message(parser, received_codec_header, codec,
                                          &codecPayload, &codecPayloadLen)) {
         case PARSER_COMPLETE: {
-          if (codec_header_received(codecPayload, codecPayloadLen, *codec,
-                                    scSet, time_sync_data) != 0) {
-            return_value = -1;
-          }
-          break;
-        }
-        case PARSER_CRITICAL_ERROR: {
-          return_value = -1;
+          codec_header_received(codecPayload, codecPayloadLen, *codec,
+                                    scSet, time_sync_data);
           break;
         }
         case PARSER_CONNECTION_ERROR: {
@@ -1072,14 +1067,8 @@ int process_data(snapcast_protocol_parser_t *parser,
           parser, &base_message_rx, &server_settings_message);
       switch (result) {
         case PARSER_COMPLETE: {
-          if (server_settings_msg_received(&server_settings_message, scSet) !=
-              0) {
-            return -1;
-          }
+          server_settings_msg_received(&server_settings_message, scSet);
           break;
-        }
-        case PARSER_CRITICAL_ERROR: {
-          return -1;
         }
         case PARSER_CONNECTION_ERROR: {
           return -2;
@@ -1338,9 +1327,7 @@ static void http_get_task(void *pvParameters) {
       int result =
           process_data(&parser, &time_sync_data, &received_codec_header, &codec,
                        &scSet, &pcmData);
-      if (result == -1) {
-        return;  // critical error in data processing
-      } else if (result == -2) {
+      if (result == -2) {
         break;  // restart connection
       }
     }

--- a/main/main.c
+++ b/main/main.c
@@ -977,10 +977,9 @@ void handle_chunk_message(codec_type_t codec, snapcastSetting_t *scSet,
     }
 
     default: {
-      ESP_LOGE(TAG,
-               "Decoder (2) not "
-               "supported");
-
+      // This should not happen, because codec header message should have been
+      // parsed before and codec should have been set to a supported value.
+      ESP_LOGE(TAG, "Decoder (2) not supported. This should never happen!");
       // critical error
       esp_restart();
 
@@ -1260,7 +1259,8 @@ static void http_get_task(void *pvParameters) {
           &hello_message, (size_t *)&(base_message_rx.size));
       if (!hello_message_serialized) {
         ESP_LOGE(TAG, "Failed to serialize hello message");
-        return;
+        // critical error
+        esp_restart();
       }
     }
 
@@ -1268,7 +1268,8 @@ static void http_get_task(void *pvParameters) {
                                     BASE_MESSAGE_SIZE);
     if (result) {
       ESP_LOGE(TAG, "Failed to serialize base message");
-      return;
+      // critical error
+      esp_restart();
     }
 
     rc1 = netconn_write(lwipNetconn, base_message_serialized, BASE_MESSAGE_SIZE,

--- a/main/main.c
+++ b/main/main.c
@@ -1022,8 +1022,7 @@ int process_data(snapcast_protocol_parser_t *parser,
       }
 
       switch (parse_wire_chunk_message(parser, &base_message_rx,
-                                       *received_codec_header, *codec, pcmData,
-                                       &wire_chnk, &decoderChunk)) {
+                                       *codec, pcmData, &wire_chnk, &decoderChunk)) {
         case PARSER_COMPLETE: {
           handle_chunk_message(*codec, scSet, pcmData, &wire_chnk);
           break;

--- a/main/main.c
+++ b/main/main.c
@@ -992,7 +992,7 @@ void handle_chunk_message(codec_type_t codec, snapcastSetting_t *scSet,
 /*
  * returns:
  * 0 if a message was (partially) processed sucessfully
- * -2 if network needs restart
+ * -1 if network needs restart
  */
 int process_data(snapcast_protocol_parser_t *parser,
                  time_sync_data_t *time_sync_data, bool *received_codec_header,
@@ -1006,7 +1006,7 @@ int process_data(snapcast_protocol_parser_t *parser,
     base_message_rx.received.usec =
         time_sync_data->now - base_message_rx.received.sec * 1000000;
   } else {  // PARSER_CONNECTION_ERROR (only these two cases for base message)
-    return -2;  // restart connection
+    return -1;  // restart connection
   }
 
   switch (base_message_rx.type) {
@@ -1025,7 +1025,7 @@ int process_data(snapcast_protocol_parser_t *parser,
           return 0;
         }
         case PARSER_CONNECTION_ERROR: {
-          return -2;
+          return -1;
         }
       }
       break;
@@ -1043,7 +1043,7 @@ int process_data(snapcast_protocol_parser_t *parser,
           break;
         }
         case PARSER_CONNECTION_ERROR: {
-          return_value = -2;
+          return_value = -1;
           break;
         }
         case PARSER_INCOMPLETE: {
@@ -1071,7 +1071,7 @@ int process_data(snapcast_protocol_parser_t *parser,
           break;
         }
         case PARSER_CONNECTION_ERROR: {
-          return -2;
+          return -1;
         }
         case PARSER_INCOMPLETE: {
           // should not happen
@@ -1090,7 +1090,7 @@ int process_data(snapcast_protocol_parser_t *parser,
         time_sync_msg_received(&base_message_rx, &time_message_rx,
                                time_sync_data, *received_codec_header);
       } else if (result == PARSER_CONNECTION_ERROR) {
-        return -2;
+        return -1;
       }  // could also be "incomplete", i.e. ignore content
       break;
     }
@@ -1098,7 +1098,7 @@ int process_data(snapcast_protocol_parser_t *parser,
     default: {
       if (parse_unknown_message(parser, &base_message_rx) ==
           PARSER_CONNECTION_ERROR) {
-        return -2;
+        return -1;
       }
       break;
     }
@@ -1327,7 +1327,7 @@ static void http_get_task(void *pvParameters) {
       int result =
           process_data(&parser, &time_sync_data, &received_codec_header, &codec,
                        &scSet, &pcmData);
-      if (result == -2) {
+      if (result != 0) {
         break;  // restart connection
       }
     }

--- a/main/main.c
+++ b/main/main.c
@@ -1157,7 +1157,7 @@ static void http_get_task(void *pvParameters) {
   if (idCounterSemaphoreHandle == NULL) {
     ESP_LOGE(TAG, "can't create id Counter Semaphore");
 
-    return;
+    esp_restart();
   }
 
   while (1) {


### PR DESCRIPTION
Maybe it makes sense to collect changes to the refactored parser in this PR.

### Critical Errors

Critical errors now explicitly restart the esp. Previously this was done by bubbling up an error value and returning from the `http_get_task`. This also simplified the code a little bit.

But there are still some questions:
- is `esp_restart()` the "correct" function to call? The doc says it does not restart peripherals. Maybe `abort()` behaves more similar to the old behavior?
- now that we are changing this anyways: do we want to switch some of these hard resets to just a restart of the network?

EDIT: Maybe we want to keep changes to the behavior and the refactoring separate. Otherwise pinning down where potential issues were introduced might become very hard in the future...


### Skipping Wire chunk
They are now skipped if there is no codec header. 