### PR TITLE
maximize partitions

### DIFF
--- a/partitions.csv
+++ b/partitions.csv
@@ -1,6 +1,6 @@
 # Name, 	Type, 	SubType, 	Offset, 	Size, Flags
-nvs,		data,	nvs,		0x9000,		32K,
-otadata,	data,	ota,		0x11000,	8K,
-phy_init,	data,	phy,		0x13000,	4K,
-ota_0,		app,	ota_0,		0x20000,	1664K,
-ota_1,		app,	ota_1,		0x1C0000,	1664K,
+nvs,		data,	nvs,		,	80K,
+otadata,	data,	ota,		,	8K,
+phy_init,	data,	phy,		,	4K,
+ota_0,		app,	ota_0,		,	1984K,
+ota_1,		app,	ota_1,		,	1984K,


### PR DESCRIPTION
Increasing all partitions to the maximum.
app partitions are aligned to 64K, so it makes no difference if nvs is 32K or 80K.

Also tried ota with old partition table installed without issues (no tas5808).