### PR TITLE
Reviewed and updated MA12070P driver. Added I2S 32-bit word mode

### DIFF
--- a/components/audio_board/Kconfig.projbuild
+++ b/components/audio_board/Kconfig.projbuild
@@ -9,6 +9,14 @@ menu "Audio Board"
 			choice and is not exposed to menuconfig.
 			See https://github.com/schreibfaul1/ESP32-audioI2S/blob/1d9b299d0197f99fc70335295adcd226dc220f88/src/Audio.cpp#L4929
 
+	config I2S_SLOT_32BIT
+		bool
+		default n
+		help
+			Forces the I2S slot width to 32 bits regardless of sample depth. Required for DACs that only
+			support 32-bit or 24-bit frames (e.g. MA120X0P whose OTP default frame size is 32 bits).
+			The IDF zero-pads 16-bit samples to fill the 32-bit slot automatically.
+
 	choice AUDIO_BOARD
 	    prompt "Audio board"
 		default ESP32_S2_KALUGA_1_V1_2_BOARD if IDF_TARGET_ESP32S2
@@ -94,6 +102,7 @@ menu "Audio Board"
 
 	    config DAC_MA120X0
 	        bool "Infineon MA120X0 ClassD AMP"
+	        select I2S_SLOT_32BIT
 
 	    config DAC_ADAU1961
 	        bool "Analog Devices ADAU1961 DAC"
@@ -206,23 +215,48 @@ menu "Audio Board"
 	             help
 			         GPIO number to control enable/disable.
 
+	         config MA120X0_NENABLE_INVERT
+	             bool "Invert nEnable pin logic (active-low)"
+	             default n
+	             depends on MA120X0_NENABLE_PIN != -1
+	             help
+	                 When enabled, the nEnable pin is driven LOW to enable the
+	                 amplifier and HIGH to disable it (active-low, as per the
+	                 MA120x0 datasheet). When disabled, HIGH = on, LOW = off.
+
 	         config MA120X0_NMUTE_PIN
 	             int "Master mute/unmute for ma120x0"
 	             default 2
 	             help
 	                 GPIO number to controm mute/unmute.
 
-	         config MERUS_NERR_PIN
+	         config MA120X0_NERR_PIN
 	             int "NERR monitor pin"
 	             default 21
 	             help
 	                 GPIO number to monitor NERROR.
 
-	         config MERUS_NCLIP_PIN
+	         config MA120X0_NCLIP_PIN
 	             int "Clip indication pin"
 	             default 22
 	             help
 	                 GPIO number low if clip observed
+
+	         config MA120X0_VOL_MAX_DB
+	             int "Maximum volume level (dB, ≤ 0)"
+	             default 0
+	             range -144 24
+	             help
+	                 Register value at slider position 100. 0 dB is the
+	                 maximum undistorted output level of the MA120x0.
+
+	         config MA120X0_VOL_MIN_DB
+	             int "Minimum volume level (dB)"
+	             default -60
+	             range -144 24
+	             help
+	                 Register value at slider position 0. Values below -60 dB
+	                 are practically inaudible on most systems.
 	     endmenu
 
 	     menu "Merus MA120 interface Configuration"

--- a/components/custom_board/ma120x0/MerusAudio.c
+++ b/components/custom_board/ma120x0/MerusAudio.c
@@ -12,365 +12,382 @@
 #include "MerusAudio.h"
 
 #include <stdint.h>
-#include <stdio.h>
 
+#include "board.h"
 #include "driver/i2c.h"
 #include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
 #include "ma120x0.h"
-// #include "ma120_rev1_all.h"
 #include "audio_hal.h"
 
 static const char *TAG = "MA120X0";
+static int s_volume = 100; /* cached volume; re-applied at CTRL_START */
 
 #define MA_NENABLE_IO CONFIG_MA120X0_NENABLE_PIN
-#define MA_NMUTE_IO CONFIG_MA120X0_NMUTE_PIN
-#define MA_NERR_IO CONFIG_MA120X0_NERR_PIN
-#define MA_NCLIP_IO CONFIG_MA120X0_NCLIP_PIN
+#define MA_NMUTE_IO   CONFIG_MA120X0_NMUTE_PIN
+#define MA_NERR_IO    CONFIG_MA120X0_NERR_PIN
+#define MA_NCLIP_IO   CONFIG_MA120X0_NCLIP_PIN
 
-static const char *I2C_TAG = "i2c";
-#define I2C_CHECK(a, str, ret)                                                 \
-  if (!(a)) {                                                                  \
-    ESP_LOGE(I2C_TAG, "%s:%d (%s):%s", __FILE__, __LINE__, __FUNCTION__, str); \
-    return (ret);                                                              \
-  }
+#ifdef CONFIG_MA120X0_NENABLE_INVERT
+#define MA_NENABLE_ON  0
+#define MA_NENABLE_OFF 1
+#else
+#define MA_NENABLE_ON  1
+#define MA_NENABLE_OFF 0
+#endif
 
-#define I2C_MASTER_NUM I2C_NUM_0    /*!< I2C port number for master dev */
+
+#define I2C_MASTER_NUM I2C_NUM_0	/*!< I2C port number for master dev */
 #define I2C_MASTER_TX_BUF_DISABLE 0 /*!< I2C master do not need buffer */
 #define I2C_MASTER_RX_BUF_DISABLE 0 /*!< I2C master do not need buffer */
-#define I2C_MASTER_FREQ_HZ 100000   /*!< I2C master clock frequency */
+#define I2C_MASTER_FREQ_HZ 100000	/*!< I2C master clock frequency */
 
-#define MA120X0_ADDR \
-  CONFIG_DAC_I2C_ADDR /*!< slave address for MA120X0 amplifier */
+#define MA120X0_ADDR                                                           \
+	CONFIG_DAC_I2C_ADDR /*!< slave address for MA120X0 amplifier */
 
 #define WRITE_BIT I2C_MASTER_WRITE /*!< I2C master write */
 #define READ_BIT I2C_MASTER_READ   /*!< I2C master read */
-#define ACK_CHECK_EN 0x1           /*!< I2C master will check ack from slave*/
+#define ACK_CHECK_EN 0x1		   /*!< I2C master will check ack from slave*/
 #define ACK_CHECK_DIS 0x0 /*!< I2C master will not check ack from slave */
-#define ACK_VAL 0x0       /*!< I2C ack value */
-#define NACK_VAL 0x1      /*!< I2C nack value */
+#define ACK_VAL 0x0		  /*!< I2C ack value */
+#define NACK_VAL 0x1	  /*!< I2C nack value */
 
 static i2c_config_t i2c_cfg;
 
 esp_err_t ma120x0_init(audio_hal_codec_config_t *codec_cfg);
 esp_err_t ma120x0_deinit(void);
+static void ma120x0_error_monitor_task(void *arg);
 esp_err_t ma120x0_config_iface(audio_hal_codec_mode_t mode,
-                               audio_hal_codec_i2s_iface_t *iface);
+							   audio_hal_codec_i2s_iface_t *iface);
 esp_err_t ma120x0_set_volume(int vol);
 esp_err_t ma120x0_get_volume(int *vol);
 esp_err_t ma120x0_set_mute(bool enable);
 esp_err_t ma120x0_ctrl(audio_hal_codec_mode_t mode,
-                       audio_hal_ctrl_t ctrl_state);
+					   audio_hal_ctrl_t ctrl_state);
 
 audio_hal_func_t AUDIO_CODEC_MA120X0_DEFAULT_HANDLE = {
-    .audio_codec_initialize = ma120x0_init,
-    .audio_codec_deinitialize = ma120x0_deinit,
-    .audio_codec_ctrl = ma120x0_ctrl,
-    .audio_codec_config_iface = ma120x0_config_iface,
-    .audio_codec_set_mute = ma120x0_set_mute,
-    .audio_codec_set_volume = ma120x0_set_volume,
-    .audio_codec_get_volume = ma120x0_get_volume,
-    .audio_hal_lock = NULL,
-    .handle = NULL,
+	.audio_codec_initialize = ma120x0_init,
+	.audio_codec_deinitialize = ma120x0_deinit,
+	.audio_codec_ctrl = ma120x0_ctrl,
+	.audio_codec_config_iface = ma120x0_config_iface,
+	.audio_codec_set_mute = ma120x0_set_mute,
+	.audio_codec_set_volume = ma120x0_set_volume,
+	.audio_codec_get_volume = ma120x0_get_volume,
+	.audio_hal_lock = NULL,
+	.handle = NULL,
 };
 
 esp_err_t ma120x0_deinit(void) {
-  // TODO
-  return ESP_OK;
+	if (MA_NMUTE_IO != GPIO_NUM_NC)
+		gpio_set_level(MA_NMUTE_IO, 0); // mute first
+	vTaskDelay(pdMS_TO_TICKS(30));
+	if (MA_NENABLE_IO != GPIO_NUM_NC)
+		gpio_set_level(MA_NENABLE_IO, MA_NENABLE_OFF);
+	return ESP_OK;
 }
 
 esp_err_t ma120x0_ctrl(audio_hal_codec_mode_t mode,
-                       audio_hal_ctrl_t ctrl_state) {
-  // TODO
-  return ESP_OK;
+					   audio_hal_ctrl_t ctrl_state) {
+	ESP_LOGD(TAG, "ctrl: mode=%d ctrl_state=%d", mode, ctrl_state);
+	if (ctrl_state == AUDIO_HAL_CTRL_START) {
+		// Re-apply volume in case it was set before the I2S clock was running.
+		ma120x0_set_volume(s_volume);
+		return ma120x0_set_mute(false);
+	} else if (ctrl_state == AUDIO_HAL_CTRL_STOP) {
+		return ma120x0_set_mute(true);
+	}
+	return ESP_OK;
 }
 
 esp_err_t ma120x0_config_iface(audio_hal_codec_mode_t mode,
-                               audio_hal_codec_i2s_iface_t *iface) {
-  // TODO
-  return ESP_OK;
+							   audio_hal_codec_i2s_iface_t *iface) {
+	// TODO
+	return ESP_OK;
 }
 
 esp_err_t ma120x0_set_volume(int vol) {
-  esp_err_t ret = ESP_OK;
-  uint8_t cmd;
-  cmd = 128 - vol;
-  ma_write_byte(0x20, 1, 64, cmd);
-  return ret;
+	esp_err_t ret = ESP_OK;
+	uint8_t cmd;
+	if (vol > 100) vol = 100;
+	if (vol < 0) vol = 0;
+	s_volume = vol;
+	// reg64: 0x18 = 0 dB, each +1 step = -1 dB.
+	// Map slider 0..100 linearly to [VOL_MIN_DB .. VOL_MAX_DB].
+	int db = CONFIG_MA120X0_VOL_MAX_DB +
+	         (100 - vol) * (CONFIG_MA120X0_VOL_MIN_DB - CONFIG_MA120X0_VOL_MAX_DB) / 100;
+	cmd = (uint8_t)(0x18 - db);
+	ret = ma_write_byte(MA120X0_ADDR, 1, 64, cmd);
+	if (ret != ESP_OK)
+		ESP_LOGW(TAG, "set_volume: I2C write failed (ret=%d)", ret);
+	else
+		ESP_LOGD(TAG, "set_volume: vol=%d cmd=0x%02x", vol, cmd);
+	return ret;
 }
 
 esp_err_t ma120x0_get_volume(int *vol) {
-  esp_err_t ret = ESP_OK;
-  uint8_t rxbuf;
-  rxbuf = ma_read_byte(0x20, 1, 64, rxbuf);
-  *vol = 128 - rxbuf;
-  return ret;
+	*vol = s_volume;
+	return ESP_OK;
 }
 
 esp_err_t ma120x0_set_mute(bool enable) {
-  esp_err_t ret = ESP_OK;
-  uint8_t nmute = (enable) ? 0 : 1 gpio_set_level(MA_NMUTE_IO, nmute);
-  return ret;
+	ESP_LOGD(TAG, "set_mute: %s", enable ? "muted" : "unmuted");
+	esp_err_t ret = ESP_OK;
+	uint8_t nmute = (enable) ? 0 : 1;
+	gpio_set_level(MA_NMUTE_IO, nmute);
+	return ret;
 }
 
 esp_err_t ma120x0_get_mute(bool *enabled) {
-  esp_err_t ret = ESP_OK;
+	esp_err_t ret = ESP_OK;
 
-  *enabled = false;  // TODO read from register
-  return ret;
+	*enabled = false; // TODO read from register
+	return ret;
 }
 
 esp_err_t ma120x0_init(audio_hal_codec_config_t *codec_cfg) {
-  esp_err_t ret = ESP_OK;
-  gpio_config_t io_conf;
+	esp_err_t ret = ESP_OK;
+	gpio_config_t io_conf;
 
-  io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
-  io_conf.mode = GPIO_MODE_OUTPUT;
-  io_conf.pin_bit_mask = (1ULL << MA_ENABLE_IO | 1ULL << MA_NMUTE_IO);
-  io_conf.pull_down_en = 0;
-  io_conf.pull_up_en = 0;
+	uint64_t output_mask = 0;
+	if (MA_NENABLE_IO != GPIO_NUM_NC)
+		output_mask |= (1ULL << MA_NENABLE_IO);
+	if (MA_NMUTE_IO != GPIO_NUM_NC)
+		output_mask |= (1ULL << MA_NMUTE_IO);
+	if (output_mask) {
+		io_conf.intr_type = GPIO_INTR_DISABLE;
+		io_conf.mode = GPIO_MODE_OUTPUT;
+		io_conf.pin_bit_mask = output_mask;
+		io_conf.pull_down_en = 0;
+		io_conf.pull_up_en = 0;
+		ESP_LOGD(TAG, "setup output nEnable=%d nMute=%d", MA_NENABLE_IO,
+				 MA_NMUTE_IO);
+		gpio_config(&io_conf);
+	}
 
-  printf("setup output %d %d \n", MA_ENABLE_IO, MA_NMUTE_IO);
-  gpio_config(&io_conf);
+	uint64_t input_mask = 0;
+	if (MA_NCLIP_IO != GPIO_NUM_NC)
+		input_mask |= (1ULL << MA_NCLIP_IO);
+	if (MA_NERR_IO != GPIO_NUM_NC)
+		input_mask |= (1ULL << MA_NERR_IO);
+	if (input_mask) {
+		io_conf.intr_type = GPIO_INTR_DISABLE;
+		io_conf.mode = GPIO_MODE_INPUT;
+		io_conf.pin_bit_mask = input_mask;
+		io_conf.pull_down_en = 0;
+		io_conf.pull_up_en = 0;
+		ESP_LOGD(TAG, "setup input nClip=%d nErr=%d", MA_NCLIP_IO, MA_NERR_IO);
+		gpio_config(&io_conf);
+	}
 
-  io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
-  io_conf.mode = GPIO_MODE_INPUT;
-  io_conf.pin_bit_mask = (1ULL << MA_NCLIP_IO | 1ULL << MA_NERR_IO);
-  io_conf.pull_down_en = 0;
-  io_conf.pull_up_en = 0;
-  printf("setup input %d %d \n", MA_NCLIP_IO, MA_NERR_IO);
-  gpio_config(&io_conf);
+	// Muted and disabled while I2C bus initialises
+	if (MA_NMUTE_IO != GPIO_NUM_NC)
+		gpio_set_level(MA_NMUTE_IO, 0);
+	if (MA_NENABLE_IO != GPIO_NUM_NC)
+		gpio_set_level(MA_NENABLE_IO, MA_NENABLE_OFF);
 
-  gpio_set_level(MA_NMUTE_IO, 0);
-  gpio_set_level(MA_ENABLE_IO, 0);
-  // required?
-  // gpio_set_drive_capability(I2C_MASTER_SCL_IO,2);
-  // gpio_set_drive_capability(I2C_MASTER_SDA_IO,2);
+	i2c_master_init();
 
-  i2c_master_init();
+	// Enable the chip and wait for PVDD to stabilize before register writes
+	if (MA_NENABLE_IO != GPIO_NUM_NC) {
+		gpio_set_level(MA_NENABLE_IO, MA_NENABLE_ON);
+		vTaskDelay(pdMS_TO_TICKS(100));
+	}
 
-  gpio_set_level(MA_ENABLE_IO, 1);
+	// i2s standard (bits 0:2), requires 32-bit word length
+	// audio_proc_enable=1  (bit 3) - enabled volume control
+	// audio_proc_release=0 (bits 4:5) - slow mode
+	// audio_proc_attack=0  (bits 6:7) - slow mode
+	ESP_LOGD(TAG, "apply_format_regs: writing reg53=0x08 for I2S format");
+	ma_write_byte(MA120X0_ADDR, 1, 53, 0x08); 
 
-  uint8_t res = ma_write_byte(0x20, 2, 1544, 0);
-  res = ma_read_byte(0x20, 2, 1544);
-  printf("Hardware version: 0x%02x\n", res);
-  printf("Scan I2C bus: ");
-  for (uint8_t addr = 0x20; addr <= 0x23; addr++) {
-    res = ma_read_byte(addr, 2, 0);
+	// Set master volume to 0 dB.
+	ma_write_byte(MA120X0_ADDR, 1, 64, 0x18);
 
-    printf(" 0x%02x => GEN2 ,", addr);
-    // printf("Scan i2c address 0x%02x read address 0 : 0x%02x \n", addr ,res);
-  }
-  printf("\n");
-  uint8_t rxbuf[32];
-  uint8_t otp[1024];
-  for (uint8_t i = 0; i < 16; i++) {
-    ma_read(0x20, 2, 0x8000 + i * 32, rxbuf, 32);
-    // printf("%04x : ",0x8000+i*32 );
-    for (uint8_t j = 0; j < 32; j++) {
-      otp[i * 32 + j] = rxbuf[j];
-    }
-  }
-  for (uint16_t i = 0; i < 16 * 32; i++) {
-    if (i % 32 == 0) {
-      printf("\n0x%04x : ", 0x8000 + i);
-    }
-    printf("%02x ", otp[i]);
-  }
+	xTaskCreate(ma120x0_error_monitor_task, "ma120x0_err", 4096, NULL, 5, NULL);
 
-  res = ma_write_byte(0x20, 2, 0x060c, 0);
-  res = ma_read(0x20, 2, 0x060c, rxbuf, 2);
-  printf("\nHardware version: 0x%02x\n", rxbuf[0]);
-
-  res = ma_read(0x20, 2, 0x0000, rxbuf, 2);
-  printf("\nAddress 0 : 0x%02x\n", rxbuf[0]);
-  ma_write_byte(0x20, 2, 0x0003, 0x50);
-  ma_write_byte(0x20, 2, 0x0004, 0x50);
-  ma_write_byte(0x20, 2, 0x0005, 0x02);
-  // ma_write_byte(0x20,2,0x0246,0x00)  ;   //
-  printf("\n");
-
-  return ret;
+	ESP_LOGI(TAG, "init complete");
+	return ret;
 }
 
-#define CRED "\x1b[31m"
-#define CGRE "\x1b[32m"
-#define CYEL "\x1b[33m"
-#define CBLU "\x1b[34m"
-#define CMAG "\x1b[35m"
-#define CYAN "\x1b[36m"
-#define CWHI "\x1b[0m"
-const char *cherr_str[] = {"Clip_stuck", "DC", "VCF", "OCP_SEV", "OCP"};
-const char *syserr1_str[] = {" X ",    " X ",   "DSP3 ", " DSP2",
-                             " DSP1 ", "DSP0 ", "ERR",   "PVT_low"};
-const char *syserr0_str[] = {"OTW",   "OTE",   "PV_uv", "PV_low",
-                             "OV_ov", " CLK ", "AUD",   " TW    "};
-// static uint8_t terr = 0;
-void ma120_read_error(uint8_t i2c_addr) {  // 0x0118 error now ch0 [clip_stuck
-                                           // dc  vcf_err  ocp_severe  ocp]
-  // 0x0119 error now ch1 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
-  // 0x011a error now system [ AE CE ... ]
-  // 0x011b error now system [DSP3 DSP2 DSP1 DSP0 OC OE]
-  // 0x011c error acc ch0 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
-  // 0x011d error acc ch1 [clip_stuck  dc  vcf_err  ocp_severe  ocp]
-  // 0x011e error acc system [7..0]
-  // 0x011f error acc system [13..8]
-  uint8_t errbuf[10] = {0};
+static void ma120x0_error_monitor_task(void *arg) {
+	vTaskDelay(pdMS_TO_TICKS(5000)); // wait for audio clock to stabilize
+	while (1) {
+		ma120_read_error(MA120X0_ADDR);
+		vTaskDelay(pdMS_TO_TICKS(5000));
+	}
+}
 
-  uint8_t res = ma_read(i2c_addr, 2, 0x0118, errbuf, 8);
+// ma_error__a (reg 124) bit definitions (from Linux driver):
+// bit 0: flycap   bit 1: overcurr  bit 2: pll/clk  bit 3: pvdd_uv
+// bit 4: otw      bit 5: ote       bit 6: low_imp   bit 7: dc_prot
+static const char * const ma_err_bit_names[] = {
+	"flycap", "overcurr", "pll/clk", "pvdd_uv",
+	"otw", "ote", "low_imp", "dc_prot"
+};
 
-  // Error flag now : RED
-  // Error flag acc : WHITE
-  // No flag set    : GREEN
-  for (int i = 0; i <= 7; i++) {  // Error now
-    printf(" %s%s ",
-           ((errbuf[3] & (1 << i)) == (1 << i))   ? CRED
-           : ((errbuf[7] & (1 << i)) == (1 << i)) ? CWHI
-                                                  : CGRE,
-           syserr1_str[i]);
-  }
-  printf(" [0x%02x 0x%02x]\n", errbuf[3], errbuf[7]);
+void ma120_read_error(uint8_t i2c_addr) {
+	// reg 124 = ma_error__a: current error flags
+	// reg 109 = ma_error_acc__a: accumulated error flags
+	uint8_t err_now = ma_read_byte(i2c_addr, 1, 124);
+	uint8_t err_acc = ma_read_byte(i2c_addr, 1, 109);
 
-  for (int i = 0; i <= 7; i++) {
-    printf(" %s%s ",
-           ((errbuf[2] & (1 << i)) == (1 << i))   ? CRED
-           : ((errbuf[6] & (1 << i)) == (1 << i)) ? CWHI
-                                                  : CGRE,
-           syserr0_str[i]);
-  }
-  printf(" [0x%02x 0x%02x]\n", errbuf[2], errbuf[6]);
+	if (err_now == 0 && err_acc == 0)
+		return;
 
-  // printf("0x011b : 0x%02x %s", rxbuf[2], l1 );
-  // printf("\nError vectors :");
-  // for (int i = 0; i<8; i++)
-  //{ printf("%02x ", errbuf[i]);
-  // }
-  // printf("\n");
+	if (err_now) {
+		ESP_LOGE(TAG, "errors now (reg124=0x%02x):", err_now);
+		for (int i = 0; i < 8; i++)
+			if (err_now & (1 << i))
+				ESP_LOGE(TAG, "  [bit%d] %s", i, ma_err_bit_names[i]);
+	}
+	if (err_acc) {
+		ESP_LOGW(TAG, "errors accumulated (reg109=0x%02x):", err_acc);
+		for (int i = 0; i < 8; i++)
+			if (err_acc & (1 << i))
+				ESP_LOGW(TAG, "  [bit%d] %s", i, ma_err_bit_names[i]);
+	}
+
+	// reg 116: i2s_data_rate (bits 1:0, 00/01/10=x1/x2/x4)
+	//          audio_in_mode_mon (bits 4:2)
+	uint8_t reg116 = ma_read_byte(i2c_addr, 1, 116);
+	ESP_LOGI(TAG, "  i2s_data_rate=%u audio_in_mode_mon=%u",
+		reg116 & 0x03, (reg116 & 0x1c) >> 2);
+
+	if (err_acc) {
+		ESP_LOGW(TAG, "clearing accumulated errors via eh_clear (reg45)");
+		// Preserve thermal_compr_en (bit 5, reset=1) while toggling eh_clear (bit 2)
+		ma_write_byte(i2c_addr, 1, 45, 0x24);
+		ma_write_byte(i2c_addr, 1, 45, 0x20);
+	}
 }
 
 void i2c_master_init() {
-  int i2c_master_port = I2C_MASTER_NUM;
-  i2c_cfg = {
-      .mode = I2C_MODE_MASTER,
-      .sda_pullup_en = GPIO_PULLUP_ENABLE,
-      .scl_pullup_en = GPIO_PULLUP_ENABLE,
-      .master.clk_speed = I2C_MASTER_FREQ_HZ,
-  };
-  get_i2c_pins(I2C_NUM_0, &i2c_cfg);
+	int i2c_master_port = I2C_MASTER_NUM;
+	i2c_cfg = (i2c_config_t){
+		.mode = I2C_MODE_MASTER,
+		.sda_pullup_en = GPIO_PULLUP_ENABLE,
+		.scl_pullup_en = GPIO_PULLUP_ENABLE,
+		.master.clk_speed = I2C_MASTER_FREQ_HZ,
+	};
+	get_i2c_pins(I2C_NUM_0, &i2c_cfg);
 
-  esp_err_t res = i2c_param_config(i2c_master_port, &i2c_cfg);
-  printf("Driver param setup : %d\n", res);
-  res = i2c_driver_install(i2c_master_port, i2c_cfg.mode,
-                           I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE,
-                           0);
-  printf("Driver installed   : %d\n", res);
+	esp_err_t res = i2c_param_config(i2c_master_port, &i2c_cfg);
+	ESP_LOGD(TAG, "I2C param config: %d", res);
+	res = i2c_driver_install(i2c_master_port, i2c_cfg.mode,
+							 I2C_MASTER_RX_BUF_DISABLE,
+							 I2C_MASTER_TX_BUF_DISABLE, 0);
+	ESP_LOGD(TAG, "I2C driver installed: %d", res);
 }
 
 esp_err_t ma_write(uint8_t i2c_addr, uint8_t prot, uint16_t address,
-                   uint8_t *wbuf, uint8_t n) {
-  bool ack = ACK_VAL;
-  i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-  i2c_master_start(cmd);
-  i2c_master_write_byte(cmd, i2c_addr << 1 | WRITE_BIT, ACK_CHECK_EN);
-  if (prot == 2) {
-    i2c_master_write_byte(cmd, (uint8_t)((address & 0xff00) >> 8), ACK_VAL);
-    i2c_master_write_byte(cmd, (uint8_t)(address & 0x00ff), ACK_VAL);
-  } else {
-    i2c_master_write_byte(cmd, (uint8_t)address, ACK_VAL);
-  }
+				   uint8_t *wbuf, uint8_t n) {
+	bool ack = ACK_VAL;
+	i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+	i2c_master_start(cmd);
+	i2c_master_write_byte(cmd, i2c_addr << 1 | WRITE_BIT, ACK_CHECK_EN);
+	if (prot == 2) {
+		i2c_master_write_byte(cmd, (uint8_t)((address & 0xff00) >> 8), ACK_VAL);
+		i2c_master_write_byte(cmd, (uint8_t)(address & 0x00ff), ACK_VAL);
+	} else {
+		i2c_master_write_byte(cmd, (uint8_t)address, ACK_VAL);
+	}
 
-  for (int i = 0; i < n; i++) {
-    if (i == n - 1) ack = NACK_VAL;
-    i2c_master_write_byte(cmd, wbuf[i], ack);
-  }
-  i2c_master_stop(cmd);
-  int ret =
-      i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_PERIOD_MS);
-  i2c_cmd_link_delete(cmd);
-  if (ret == ESP_FAIL) {
-    return ret;
-  }
-  return ESP_OK;
+	for (int i = 0; i < n; i++) {
+		if (i == n - 1)
+			ack = NACK_VAL;
+		i2c_master_write_byte(cmd, wbuf[i], ack);
+	}
+	i2c_master_stop(cmd);
+	int ret =
+		i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_PERIOD_MS);
+	i2c_cmd_link_delete(cmd);
+	if (ret == ESP_FAIL) {
+		return ret;
+	}
+	return ESP_OK;
 }
 
 esp_err_t ma_write_byte(uint8_t i2c_addr, uint8_t prot, uint16_t address,
-                        uint8_t value) {
-  printf("%04x %02x\n", address, value);
-  esp_err_t ret = 0;
-  i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-  i2c_master_start(cmd);
-  i2c_master_write_byte(cmd, (i2c_addr << 1) | WRITE_BIT, ACK_CHECK_EN);
-  if (prot == 2) {
-    i2c_master_write_byte(cmd, (uint8_t)((address & 0xff00) >> 8), ACK_VAL);
-    i2c_master_write_byte(cmd, (uint8_t)(address & 0x00ff), ACK_VAL);
-  } else {
-    i2c_master_write_byte(cmd, (uint8_t)address, ACK_VAL);
-  }
-  i2c_master_write_byte(cmd, value, ACK_VAL);
-  i2c_master_stop(cmd);
-  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_PERIOD_MS);
-  i2c_cmd_link_delete(cmd);
-  if (ret == ESP_FAIL) {
-    printf("ESP_I2C_WRITE ERROR : %d\n", ret);
-    return ret;
-  }
-  return ESP_OK;
+						uint8_t value) {
+	ESP_LOGD(TAG, "write addr=0x%04x val=0x%02x", address, value);
+	esp_err_t ret = 0;
+	i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+	i2c_master_start(cmd);
+	i2c_master_write_byte(cmd, (i2c_addr << 1) | WRITE_BIT, ACK_CHECK_EN);
+	if (prot == 2) {
+		i2c_master_write_byte(cmd, (uint8_t)((address & 0xff00) >> 8), ACK_VAL);
+		i2c_master_write_byte(cmd, (uint8_t)(address & 0x00ff), ACK_VAL);
+	} else {
+		i2c_master_write_byte(cmd, (uint8_t)address, ACK_VAL);
+	}
+	i2c_master_write_byte(cmd, value, ACK_VAL);
+	i2c_master_stop(cmd);
+	ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_PERIOD_MS);
+	i2c_cmd_link_delete(cmd);
+	if (ret != ESP_OK) {
+		ESP_LOGW(TAG, "I2C write failed addr=0x%02x reg=%u ret=%d", i2c_addr, address, ret);
+		return ret;
+	}
+	return ESP_OK;
 }
 
 esp_err_t ma_read(uint8_t i2c_addr, uint8_t prot, uint16_t address,
-                  uint8_t *rbuf, uint8_t n) {
-  esp_err_t ret;
-  i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-  if (cmd == NULL) {
-    printf("ERROR handle null\n");
-  }
-  i2c_master_start(cmd);
-  i2c_master_write_byte(cmd, (i2c_addr << 1) | WRITE_BIT, ACK_CHECK_EN);
-  if (prot == 2) {
-    i2c_master_write_byte(cmd, (uint8_t)((address & 0xff00) >> 8), ACK_VAL);
-    i2c_master_write_byte(cmd, (uint8_t)(address & 0x00ff), ACK_VAL);
-  } else {
-    i2c_master_write_byte(cmd, (uint8_t)address, ACK_VAL);
-  }
-  i2c_master_start(cmd);
-  i2c_master_write_byte(cmd, (i2c_addr << 1) | READ_BIT, ACK_CHECK_EN);
-  // if (n == 1 )
-  i2c_master_read(cmd, rbuf, n - 1, ACK_VAL);
-  // for (uint8_t i = 0;i<n;i++)
-  // { i2c_master_read_byte(cmd, rbuf++, ACK_VAL); }
-  i2c_master_read_byte(cmd, rbuf + n - 1, NACK_VAL);
-  i2c_master_stop(cmd);
-  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 100 / portTICK_PERIOD_MS);
-  i2c_cmd_link_delete(cmd);
-  if (ret == ESP_FAIL) {
-    printf("i2c Error read - readback\n");
-    return ESP_FAIL;
-  }
-  return ret;
+				  uint8_t *rbuf, uint8_t n) {
+	esp_err_t ret;
+	i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+	if (cmd == NULL) {
+		ESP_LOGE(TAG, "I2C cmd handle null");
+	}
+	i2c_master_start(cmd);
+	i2c_master_write_byte(cmd, (i2c_addr << 1) | WRITE_BIT, ACK_CHECK_EN);
+	if (prot == 2) {
+		i2c_master_write_byte(cmd, (uint8_t)((address & 0xff00) >> 8), ACK_VAL);
+		i2c_master_write_byte(cmd, (uint8_t)(address & 0x00ff), ACK_VAL);
+	} else {
+		i2c_master_write_byte(cmd, (uint8_t)address, ACK_VAL);
+	}
+	i2c_master_start(cmd);
+	i2c_master_write_byte(cmd, (i2c_addr << 1) | READ_BIT, ACK_CHECK_EN);
+	// if (n == 1 )
+	i2c_master_read(cmd, rbuf, n - 1, ACK_VAL);
+	// for (uint8_t i = 0;i<n;i++)
+	// { i2c_master_read_byte(cmd, rbuf++, ACK_VAL); }
+	i2c_master_read_byte(cmd, rbuf + n - 1, NACK_VAL);
+	i2c_master_stop(cmd);
+	ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 100 / portTICK_PERIOD_MS);
+	i2c_cmd_link_delete(cmd);
+	if (ret == ESP_FAIL) {
+		ESP_LOGD(TAG, "I2C read error - readback");
+		return ESP_FAIL;
+	}
+	return ret;
 }
 
 uint8_t ma_read_byte(uint8_t i2c_addr, uint8_t prot, uint16_t address) {
-  uint8_t value = 0;
-  esp_err_t ret;
-  i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-  i2c_master_start(cmd);  // Send i2c start on bus
-  i2c_master_write_byte(cmd, (i2c_addr << 1) | WRITE_BIT, ACK_CHECK_EN);
-  if (prot == 2) {
-    i2c_master_write_byte(cmd, (uint8_t)((address & 0xff00) >> 8), ACK_VAL);
-    i2c_master_write_byte(cmd, (uint8_t)(address & 0x00ff), ACK_VAL);
-  } else {
-    i2c_master_write_byte(cmd, (uint8_t)address, ACK_VAL);
-  }
-  i2c_master_start(cmd);  // Repeated start
-  i2c_master_write_byte(cmd, (i2c_addr << 1) | READ_BIT, ACK_CHECK_EN);
+	uint8_t value = 0;
+	esp_err_t ret;
+	i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+	i2c_master_start(cmd); // Send i2c start on bus
+	i2c_master_write_byte(cmd, (i2c_addr << 1) | WRITE_BIT, ACK_CHECK_EN);
+	if (prot == 2) {
+		i2c_master_write_byte(cmd, (uint8_t)((address & 0xff00) >> 8), ACK_VAL);
+		i2c_master_write_byte(cmd, (uint8_t)(address & 0x00ff), ACK_VAL);
+	} else {
+		i2c_master_write_byte(cmd, (uint8_t)address, ACK_VAL);
+	}
+	i2c_master_start(cmd); // Repeated start
+	i2c_master_write_byte(cmd, (i2c_addr << 1) | READ_BIT, ACK_CHECK_EN);
 
-  i2c_master_read_byte(cmd, &value, NACK_VAL);
+	i2c_master_read_byte(cmd, &value, NACK_VAL);
 
-  i2c_master_stop(cmd);
-  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_PERIOD_MS);
-  i2c_cmd_link_delete(cmd);
-  if (ret == ESP_FAIL) {
-    printf("i2c Error read - readback\n");
-    return ESP_FAIL;
-  }
-  return value;
+	i2c_master_stop(cmd);
+	ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_PERIOD_MS);
+	i2c_cmd_link_delete(cmd);
+	if (ret == ESP_FAIL) {
+		ESP_LOGD(TAG, "I2C read error - readback");
+		return ESP_FAIL;
+	}
+	return value;
 }

--- a/components/lightsnapcast/player.c
+++ b/components/lightsnapcast/player.c
@@ -338,6 +338,12 @@ static esp_err_t player_setup_i2s(snapcastSetting_t *setting) {
 #endif
       .gpio_cfg = pin_config0,
   };
+#if CONFIG_I2S_SLOT_32BIT
+  // MA120X0P (and similar) only support 32-bit or 24-bit BCLK frames.
+  // Override slot width so the ESP32 sends 32 BCLK pulses per channel;
+  // 16-bit samples are zero-padded by the IDF automatically.
+  tx_std_cfg.slot_cfg.slot_bit_width = I2S_SLOT_BIT_WIDTH_32BIT;
+#endif
 
   ESP_ERROR_CHECK(i2s_channel_init_std_mode(tx_chan, &tx_std_cfg));
   // This prevents pops/clicks on some I2S codecs


### PR DESCRIPTION
Hey folks. 

Some time ago, I've created a board with Infineon MA12070P DAC: [Loud-ESP32-Plus](https://sonocotta.com/loud-esp32/)
I finally found some time to try to spin it up with the driver included with snapclient. As it turned out, code was really raw, not compiling at all, and contained multiple DAC specific errros. I did a full review and rewrite, testing different DAC modes and settings. These are the ones I found optimal.

One thing that took me a long time to figure out - this DAC required 32-bit word on I2S in standard mode. I had to update `player.c` to change to 32-bit, when this DAC is selected. 

Other implementations I took as a reference:
1. Linux kernel version: https://github.com/raspberrypi/linux/blob/rpi-6.12.y/sound/soc/codecs/ma120x0p.c
2. muVox project: https://github.com/muvox-io/euphonium/blob/develop/src/core/fs/pkgs/platform_esp32/src/dacs/ma12070p_driver.be