### PR TITLE
Add OTA firmware upload via web interface

### DIFF
--- a/components/settings_manager/settings_manager.c
+++ b/components/settings_manager/settings_manager.c
@@ -525,6 +525,13 @@ esp_err_t settings_get_json(char *json_out, size_t max_len) {
     cJSON_AddBoolToObject(root, "eq_available", false);
 #endif
 
+    // Add web OTA availability flag
+#if CONFIG_SNAPCLIENT_WEB_OTA
+    cJSON_AddBoolToObject(root, "web_ota_enabled", true);
+#else
+    cJSON_AddBoolToObject(root, "web_ota_enabled", false);
+#endif
+
     // Render to string
     char *json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);

--- a/components/ui_http_server/CMakeLists.txt
+++ b/components/ui_http_server/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(SRCS "ui_http_server.c"
                        INCLUDE_DIRS "include"
-                       REQUIRES esp_http_server settings_manager dsp_processor_settings tas5805m_settings
+                       REQUIRES esp_http_server settings_manager dsp_processor_settings tas5805m_settings app_update
                        PRIV_REQUIRES custom_board
                        EMBED_TXTFILES html/index.html
                                       html/index.js
@@ -10,4 +10,5 @@ idf_component_register(SRCS "ui_http_server.c"
                                       html/dsp-settings.html
                                       html/dac-settings.html
                                       html/eq-settings.html
+                                      html/ota-update.html
                        EMBED_FILES html/favicon.ico)

--- a/components/ui_http_server/CMakeLists.txt
+++ b/components/ui_http_server/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(SRCS "ui_http_server.c"
+                             "ota_handlers.c"
                        INCLUDE_DIRS "include"
                        REQUIRES esp_http_server settings_manager dsp_processor_settings tas5805m_settings app_update
                        PRIV_REQUIRES custom_board

--- a/components/ui_http_server/html/index.html
+++ b/components/ui_http_server/html/index.html
@@ -92,6 +92,7 @@
       <li id="dsp-tab" style="display: none;"><a href="#" class="nav-link" data-page="dsp-settings.html">DSP Settings</a></li>
       <li id="dac-tab" style="display: none;"><a href="#" class="nav-link" data-page="dac-settings.html">DAC Settings</a></li>
       <li id="eq-tab" style="display: none;"><a href="#" class="nav-link" data-page="eq-settings.html">EQ</a></li>
+      <li id="ota-tab" style="display: none;"><a href="#" class="nav-link" data-page="ota-update.html">OTA Update</a></li>
     </ul>
   </nav>
 
@@ -133,6 +134,14 @@
           const eqTab = document.getElementById('eq-tab');
           if (eqTab) {
             eqTab.style.display = 'block';
+          }
+        }
+
+        // Show OTA tab if web_ota_enabled is true
+        if (capabilities.web_ota_enabled === true) {
+          const otaTab = document.getElementById('ota-tab');
+          if (otaTab) {
+            otaTab.style.display = 'block';
           }
         }
       } catch (error) {

--- a/components/ui_http_server/html/ota-update.html
+++ b/components/ui_http_server/html/ota-update.html
@@ -296,7 +296,7 @@
 
     // ── Firmware info rendering ───────────────────────────────────────────────
 
-    function renderMeta(desc) {
+    function renderMeta(desc, showShaLabel = true) {
       if (!desc) return '<div class="placeholder">Unknown</div>';
 
       const rows = [
@@ -317,7 +317,7 @@
 
       if (desc.sha256) {
         const match = currentSha256 && desc.sha256 === currentSha256;
-        const cls   = currentSha256 ? (match ? 'sha256-match' : 'sha256-diff') : '';
+        const cls   = (showShaLabel && currentSha256) ? (match ? 'sha256-match' : 'sha256-diff') : '';
         const label = cls === 'sha256-match' ? ' ✓ same as running'
                     : cls === 'sha256-diff'  ? ' ✗ different'
                     : '';
@@ -337,7 +337,7 @@
         if (!resp.ok) throw new Error('HTTP ' + resp.status);
         const data = await resp.json();
         currentSha256 = data.sha256 || null;
-        el.innerHTML = renderMeta(data);
+        el.innerHTML = renderMeta(data, false);
         // Re-render selected card now that we have currentSha256 for comparison
         if (selectedDesc) {
           document.getElementById('info-selected').innerHTML = renderMeta(selectedDesc);
@@ -395,6 +395,7 @@
           progressText.textContent = '';
 
           const isNew = currentSha256 && data.sha256 && data.sha256 !== currentSha256;
+          currentSha256 = data.sha256 || null;
           const meta  = renderMeta(data);
 
           showStatus(isNew
@@ -402,8 +403,7 @@
             : '<div class="success"><strong>Device restarted successfully.</strong>'  + meta + '</div>');
 
           // Refresh both cards
-          currentSha256 = data.sha256 || null;
-          document.getElementById('info-current').innerHTML  = renderMeta(data);
+          document.getElementById('info-current').innerHTML  = renderMeta(data, false);
           document.getElementById('info-selected').innerHTML = '<div class="placeholder">No file selected</div>';
           selectedDesc = null;
           fileInput.value = '';

--- a/components/ui_http_server/html/ota-update.html
+++ b/components/ui_http_server/html/ota-update.html
@@ -1,0 +1,485 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>OTA Update</title>
+  <link rel="stylesheet" href="styles.css">
+  <script src="index.js"></script>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      max-width: 800px;
+      margin: 20px auto;
+      padding: 20px;
+      background-color: #f5f5f5;
+    }
+
+    h1 {
+      color: #333;
+      text-align: center;
+      margin-bottom: 30px;
+    }
+
+    .settings-container {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .setting-control {
+      background-color: white;
+      padding: 20px;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+
+    .setting-control label {
+      display: block;
+      font-weight: bold;
+      margin-bottom: 10px;
+      color: #333;
+      font-size: 16px;
+    }
+
+    .setting-control .description {
+      font-size: 14px;
+      color: #666;
+      margin-bottom: 15px;
+      font-style: italic;
+    }
+
+    .firmware-cards {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+    }
+
+    @media (max-width: 560px) {
+      .firmware-cards { grid-template-columns: 1fr; }
+    }
+
+    .firmware-card {
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      padding: 16px;
+    }
+
+    .firmware-card .card-title {
+      font-weight: bold;
+      font-size: 14px;
+      color: #333;
+      margin-bottom: 10px;
+      padding-bottom: 6px;
+      border-bottom: 2px solid #e9ecef;
+    }
+
+    .firmware-card.card-new .card-title {
+      border-bottom-color: #007bff;
+    }
+
+    .firmware-meta {
+      font-size: 13px;
+      color: #555;
+    }
+
+    .firmware-meta .meta-row {
+      display: flex;
+      margin-bottom: 4px;
+      gap: 6px;
+    }
+
+    .firmware-meta .meta-key {
+      color: #888;
+      min-width: 80px;
+      flex-shrink: 0;
+    }
+
+    .firmware-meta .meta-val {
+      font-weight: 500;
+      word-break: break-all;
+    }
+
+    .sha256-row {
+      margin-top: 8px;
+      font-family: monospace;
+      font-size: 10px;
+      color: #aaa;
+      word-break: break-all;
+    }
+
+    .sha256-match { color: #28a745; font-weight: bold; }
+    .sha256-diff  { color: #dc3545; font-weight: bold; }
+
+    .placeholder {
+      font-size: 13px;
+      color: #aaa;
+      font-style: italic;
+    }
+
+    .btn {
+      padding: 10px 20px;
+      font-size: 14px;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: background-color 0.3s;
+    }
+
+    .btn-primary { background-color: #007bff; color: white; }
+    .btn-primary:hover { background-color: #0056b3; }
+    .btn-primary:disabled { background-color: #6c757d; cursor: not-allowed; }
+
+    .error   { background-color: #f8d7da; color: #721c24; padding: 15px; border-radius: 4px; margin: 10px 0; }
+    .success { background-color: #d4edda; color: #155724; padding: 15px; border-radius: 4px; margin: 10px 0; }
+    .warning { background-color: #fff3cd; color: #856404; padding: 15px; border-radius: 4px; margin: 10px 0; }
+
+    .file-input-wrapper { margin: 12px 0; }
+
+    input[type="file"] { font-size: 14px; padding: 6px 0; }
+
+    .file-info { font-size: 13px; color: #555; margin-top: 4px; }
+
+    .parse-error { font-size: 13px; color: #856404; margin-top: 6px; }
+
+    .progress-container { display: none; margin-top: 14px; }
+
+    .progress-bar-bg {
+      background: #e9ecef;
+      border-radius: 4px;
+      height: 22px;
+      overflow: hidden;
+    }
+
+    .progress-bar {
+      background: #007bff;
+      height: 100%;
+      width: 0%;
+      transition: width 0.2s ease;
+    }
+
+    .progress-bar.done { background: #28a745; }
+
+    .progress-text {
+      text-align: center;
+      font-size: 13px;
+      color: #555;
+      margin-top: 6px;
+    }
+  </style>
+</head>
+<body>
+  <h1>OTA Firmware Update</h1>
+
+  <div class="settings-container">
+
+    <div class="firmware-cards">
+      <div class="firmware-card" id="card-current">
+        <div class="card-title">Current Firmware</div>
+        <div id="info-current"><div class="placeholder">Loading…</div></div>
+      </div>
+      <div class="firmware-card card-new" id="card-selected">
+        <div class="card-title">Selected Firmware</div>
+        <div id="info-selected"><div class="placeholder">No file selected</div></div>
+      </div>
+    </div>
+
+    <div class="setting-control">
+      <label>Upload Firmware</label>
+      <div class="description">
+        Select a compiled <code>.bin</code> firmware file. The device will stop playback,
+        flash the new firmware, and restart automatically.
+      </div>
+
+      <div id="status-area"></div>
+
+      <div class="file-input-wrapper">
+        <input type="file" id="firmware-file" accept=".bin">
+        <div id="file-info" class="file-info"></div>
+        <div id="parse-error" class="parse-error"></div>
+      </div>
+
+      <div class="progress-container" id="progress-container">
+        <div class="progress-bar-bg">
+          <div class="progress-bar" id="progress-bar"></div>
+        </div>
+        <div class="progress-text" id="progress-text"></div>
+      </div>
+
+      <div style="margin-top: 16px;">
+        <button class="btn btn-primary" id="upload-btn" disabled onclick="startUpload()">
+          Upload Firmware
+        </button>
+      </div>
+    </div>
+
+    <div class="warning">
+      <strong>Warning:</strong> Do not power off or disconnect the device during the
+      update. The device will restart automatically once the new firmware is written.
+    </div>
+
+  </div>
+
+  <script>
+    'use strict';
+
+    const ESP_APP_DESC_MAGIC = 0xABCD5432;
+
+    // Offsets within esp_app_desc_t from the magic word
+    const OFF_SECURE_VER  =   4;
+    const OFF_VERSION     =  16;
+    const OFF_PROJ_NAME   =  48;
+    const OFF_TIME        =  80;
+    const OFF_DATE        =  96;
+    const OFF_IDF_VER     = 112;
+    const OFF_SHA256      = 144;
+    const STRUCT_SIZE     = 256;
+
+    const fileInput      = document.getElementById('firmware-file');
+    const uploadBtn      = document.getElementById('upload-btn');
+    const fileInfo       = document.getElementById('file-info');
+    const parseError     = document.getElementById('parse-error');
+    const statusArea     = document.getElementById('status-area');
+    const progressContainer = document.getElementById('progress-container');
+    const progressBar    = document.getElementById('progress-bar');
+    const progressText   = document.getElementById('progress-text');
+
+    const backendUrl = (typeof BACKEND_URL !== 'undefined') ? BACKEND_URL : '';
+
+    let currentSha256  = null;
+    let selectedDesc   = null;
+
+    // ── Utilities ────────────────────────────────────────────────────────────
+
+    function escapeHtml(text) {
+      const d = document.createElement('div');
+      d.textContent = String(text);
+      return d.innerHTML;
+    }
+
+    function showStatus(html) { statusArea.innerHTML = html; }
+
+    function readNullTermString(bytes, offset, maxLen) {
+      const slice = bytes.subarray(offset, offset + maxLen);
+      const end = slice.indexOf(0);
+      return new TextDecoder().decode(end >= 0 ? slice.subarray(0, end) : slice);
+    }
+
+    function bytesToHex(bytes, offset, len) {
+      return Array.from(bytes.subarray(offset, offset + len))
+        .map(b => b.toString(16).padStart(2, '0')).join('');
+    }
+
+    // ── esp_app_desc_t parser ─────────────────────────────────────────────────
+
+    function parseEspAppDesc(buffer) {
+      const bytes = new Uint8Array(buffer);
+      const view  = new DataView(buffer);
+
+      // Scan for magic word (little-endian), aligned to 4 bytes
+      for (let i = 0; i + STRUCT_SIZE <= bytes.length; i += 4) {
+        if (view.getUint32(i, true) !== ESP_APP_DESC_MAGIC) continue;
+
+        return {
+          secure_version: view.getUint32(i + OFF_SECURE_VER, true),
+          version:        readNullTermString(bytes, i + OFF_VERSION,   32),
+          project_name:   readNullTermString(bytes, i + OFF_PROJ_NAME, 32),
+          compile_time:   readNullTermString(bytes, i + OFF_TIME,      16),
+          compile_date:   readNullTermString(bytes, i + OFF_DATE,      16),
+          idf_version:    readNullTermString(bytes, i + OFF_IDF_VER,   32),
+          sha256:         bytesToHex(bytes, i + OFF_SHA256, 32),
+        };
+      }
+      return null;
+    }
+
+    // ── Firmware info rendering ───────────────────────────────────────────────
+
+    function renderMeta(desc) {
+      if (!desc) return '<div class="placeholder">Unknown</div>';
+
+      const rows = [
+        ['Version',  desc.version      || '—'],
+        ['Project',  desc.project_name || '—'],
+        ['Built',    desc.compile_date + ' ' + desc.compile_time],
+        ['IDF',      desc.idf_version  || '—'],
+      ];
+
+      let html = '<div class="firmware-meta">';
+      for (const [k, v] of rows) {
+        html += '<div class="meta-row">'
+          + '<span class="meta-key">' + k + '</span>'
+          + '<span class="meta-val">'  + escapeHtml(v.trim()) + '</span>'
+          + '</div>';
+      }
+      html += '</div>';
+
+      if (desc.sha256) {
+        const match = currentSha256 && desc.sha256 === currentSha256;
+        const cls   = currentSha256 ? (match ? 'sha256-match' : 'sha256-diff') : '';
+        const label = cls === 'sha256-match' ? ' ✓ same as running'
+                    : cls === 'sha256-diff'  ? ' ✗ different'
+                    : '';
+        html += '<div class="sha256-row"><span class="' + cls + '">'
+              + escapeHtml(desc.sha256) + label + '</span></div>';
+      }
+
+      return html;
+    }
+
+    // ── Load current firmware from device ────────────────────────────────────
+
+    async function loadCurrentFirmware() {
+      const el = document.getElementById('info-current');
+      try {
+        const resp = await fetch(backendUrl + '/api/ota/status');
+        if (!resp.ok) throw new Error('HTTP ' + resp.status);
+        const data = await resp.json();
+        currentSha256 = data.sha256 || null;
+        el.innerHTML = renderMeta(data);
+        // Re-render selected card now that we have currentSha256 for comparison
+        if (selectedDesc) {
+          document.getElementById('info-selected').innerHTML = renderMeta(selectedDesc);
+        }
+      } catch (e) {
+        el.innerHTML = '<div class="placeholder">Unavailable</div>';
+      }
+    }
+
+    // ── File selection ────────────────────────────────────────────────────────
+
+    fileInput.addEventListener('change', function () {
+      const file = this.files[0];
+      parseError.textContent = '';
+      selectedDesc = null;
+
+      if (!file) {
+        fileInfo.textContent = '';
+        uploadBtn.disabled = true;
+        document.getElementById('info-selected').innerHTML = '<div class="placeholder">No file selected</div>';
+        return;
+      }
+
+      const kb = (file.size / 1024).toFixed(1);
+      fileInfo.textContent = file.name + ' — ' + kb + ' KB';
+      uploadBtn.disabled = false;
+
+      const reader = new FileReader();
+      reader.onload = function (e) {
+        const desc = parseEspAppDesc(e.target.result);
+        if (desc) {
+          selectedDesc = desc;
+          document.getElementById('info-selected').innerHTML = renderMeta(desc);
+        } else {
+          document.getElementById('info-selected').innerHTML = '<div class="placeholder">Could not parse firmware metadata</div>';
+          parseError.textContent = 'Warning: esp_app_desc magic word not found — this may not be a valid ESP-IDF firmware image.';
+        }
+      };
+      reader.readAsArrayBuffer(file);
+    });
+
+    // ── Upload + post-flash polling ───────────────────────────────────────────
+
+    async function pollForRestart() {
+      const maxAttempts = 30;
+      for (let i = 0; i < maxAttempts; i++) {
+        await new Promise(r => setTimeout(r, 2000));
+        progressText.textContent = 'Waiting for device to restart… (' + ((maxAttempts - i - 1) * 2) + 's)';
+        try {
+          const resp = await fetch(backendUrl + '/api/ota/status');
+          if (!resp.ok) continue;
+          const data = await resp.json();
+
+          progressBar.classList.add('done');
+          progressText.textContent = '';
+
+          const isNew = currentSha256 && data.sha256 && data.sha256 !== currentSha256;
+          const meta  = renderMeta(data);
+
+          showStatus(isNew
+            ? '<div class="success"><strong>New firmware confirmed running.</strong>' + meta + '</div>'
+            : '<div class="success"><strong>Device restarted successfully.</strong>'  + meta + '</div>');
+
+          // Refresh both cards
+          currentSha256 = data.sha256 || null;
+          document.getElementById('info-current').innerHTML  = renderMeta(data);
+          document.getElementById('info-selected').innerHTML = '<div class="placeholder">No file selected</div>';
+          selectedDesc = null;
+          fileInput.value = '';
+          fileInfo.textContent = '';
+
+          uploadBtn.disabled = true;
+          fileInput.disabled = false;
+          return;
+        } catch (e) {
+          // Still restarting
+        }
+      }
+
+      progressText.textContent = '';
+      showStatus('<div class="warning">Device did not respond within 60 seconds. It may still be restarting.</div>');
+      uploadBtn.disabled = false;
+      fileInput.disabled = false;
+    }
+
+    function startUpload() {
+      const file = fileInput.files[0];
+      if (!file) return;
+
+      uploadBtn.disabled = true;
+      fileInput.disabled = true;
+      showStatus('');
+
+      progressContainer.style.display = 'block';
+      progressBar.style.width = '0%';
+      progressBar.classList.remove('done');
+      progressText.textContent = 'Starting upload…';
+
+      const xhr = new XMLHttpRequest();
+      xhr.open('POST', backendUrl + '/api/ota/upload', true);
+      xhr.setRequestHeader('Content-Type', 'application/octet-stream');
+
+      xhr.upload.addEventListener('progress', function (e) {
+        if (e.lengthComputable) {
+          const pct      = Math.round((e.loaded / e.total) * 100);
+          const loadedKB = (e.loaded / 1024).toFixed(0);
+          const totalKB  = (e.total  / 1024).toFixed(0);
+          progressBar.style.width = pct + '%';
+          progressText.textContent = 'Uploading: ' + pct + '% (' + loadedKB + ' / ' + totalKB + ' KB)';
+        }
+      });
+
+      function onUploadDone() {
+        progressBar.style.width = '100%';
+        progressText.textContent = 'Upload complete — waiting for restart…';
+        pollForRestart();
+      }
+
+      xhr.onload = function () {
+        if (xhr.status === 200) {
+          onUploadDone();
+        } else {
+          let msg = 'Upload failed (HTTP ' + xhr.status + ')';
+          try { const r = JSON.parse(xhr.responseText); if (r.error) msg = r.error; } catch (e) { /* ignore */ }
+          progressText.textContent = '';
+          showStatus('<div class="error">Error: ' + escapeHtml(msg) + '</div>');
+          uploadBtn.disabled = false;
+          fileInput.disabled = false;
+        }
+      };
+
+      xhr.onerror   = onUploadDone; // connection dropped = device restarted
+      xhr.ontimeout = function () {
+        showStatus('<div class="error">Error: Upload timed out.</div>');
+        uploadBtn.disabled = false;
+        fileInput.disabled = false;
+      };
+
+      xhr.send(file);
+    }
+
+    document.addEventListener('DOMContentLoaded', loadCurrentFirmware);
+  </script>
+</body>
+</html>

--- a/components/ui_http_server/html/ota-update.html
+++ b/components/ui_http_server/html/ota-update.html
@@ -394,13 +394,16 @@
           progressBar.classList.add('done');
           progressText.textContent = '';
 
-          const isNew = currentSha256 && data.sha256 && data.sha256 !== currentSha256;
-          currentSha256 = data.sha256 || null;
+          const isNew    = currentSha256 && data.sha256 && data.sha256 !== currentSha256;
+          const isFailed = currentSha256 && data.sha256 && data.sha256 === currentSha256;
           const meta  = renderMeta(data);
+          currentSha256 = data.sha256 || null;
 
           showStatus(isNew
             ? '<div class="success"><strong>New firmware confirmed running.</strong>' + meta + '</div>'
-            : '<div class="success"><strong>Device restarted successfully.</strong>'  + meta + '</div>');
+            : isFailed
+              ? '<div class="error"><strong>OTA update failed — device is running the previous firmware.</strong>' + meta + '</div>'
+              : '<div class="warning"><strong>Device restarted — unable to verify firmware (no baseline).</strong>'  + meta + '</div>');
 
           // Refresh both cards
           document.getElementById('info-current').innerHTML  = renderMeta(data, false);

--- a/components/ui_http_server/include/ota_handlers.h
+++ b/components/ui_http_server/include/ota_handlers.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "esp_http_server.h"
+
+#if CONFIG_SNAPCLIENT_WEB_OTA
+void ota_register_handlers(httpd_handle_t server);
+#endif

--- a/components/ui_http_server/ota_handlers.c
+++ b/components/ui_http_server/ota_handlers.c
@@ -1,0 +1,211 @@
+#include "ota_handlers.h"
+
+#if CONFIG_SNAPCLIENT_WEB_OTA
+
+#include <string.h>
+#include "esp_app_desc.h"
+#include "esp_err.h"
+#include "esp_http_server.h"
+#include "esp_log.h"
+#include "esp_ota_ops.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+static const char *TAG = "OTA_HTTP";
+
+extern void sc_stop_snapclient(void);
+
+#define OTA_HTTP_CHUNK_SIZE 4096
+
+static void set_cors_headers(httpd_req_t *req) {
+	httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+	httpd_resp_set_hdr(req, "Access-Control-Allow-Methods",
+	                   "GET, POST, DELETE, OPTIONS");
+	httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Content-Type");
+	httpd_resp_set_hdr(req, "Access-Control-Max-Age", "86400");
+}
+
+static esp_err_t options_handler(httpd_req_t *req) {
+	set_cors_headers(req);
+	httpd_resp_set_status(req, "204 No Content");
+	httpd_resp_send(req, NULL, 0);
+	return ESP_OK;
+}
+
+static void restart_task(void *pv) {
+	vTaskDelay(pdMS_TO_TICKS(200));
+	esp_restart();
+	vTaskDelete(NULL);
+}
+
+/*
+ * POST /api/ota/upload
+ * Receives a raw firmware binary, writes it to the inactive OTA partition,
+ * sets it as the next boot partition, and restarts.
+ */
+static esp_err_t ota_upload_handler(httpd_req_t *req) {
+	ESP_LOGD(TAG, "%s: uri=%s content_len=%d", __func__, req->uri, req->content_len);
+
+	set_cors_headers(req);
+	httpd_resp_set_type(req, "application/json");
+
+	if (req->content_len == 0) {
+		httpd_resp_set_status(req, "400 Bad Request");
+		httpd_resp_sendstr(req, "{\"error\": \"No firmware data\"}");
+		return ESP_OK;
+	}
+
+	ESP_LOGI(TAG, "%s: OTA upload started, %d bytes", __func__, req->content_len);
+
+	sc_stop_snapclient();
+	vTaskDelay(pdMS_TO_TICKS(500));
+
+	const esp_partition_t *update_partition = esp_ota_get_next_update_partition(NULL);
+	if (!update_partition) {
+		httpd_resp_set_status(req, "500 Internal Server Error");
+		httpd_resp_sendstr(req, "{\"error\": \"No OTA partition available\"}");
+		return ESP_OK;
+	}
+
+	esp_ota_handle_t ota_handle;
+	esp_err_t err = esp_ota_begin(update_partition, req->content_len, &ota_handle);
+	if (err != ESP_OK) {
+		ESP_LOGE(TAG, "%s: esp_ota_begin failed: %s", __func__, esp_err_to_name(err));
+		httpd_resp_set_status(req, "500 Internal Server Error");
+		httpd_resp_sendstr(req, "{\"error\": \"OTA begin failed\"}");
+		return ESP_OK;
+	}
+
+	char *buf = (char *)malloc(OTA_HTTP_CHUNK_SIZE);
+	if (!buf) {
+		esp_ota_abort(ota_handle);
+		httpd_resp_set_status(req, "500 Internal Server Error");
+		httpd_resp_sendstr(req, "{\"error\": \"Memory allocation failed\"}");
+		return ESP_OK;
+	}
+
+	int remaining = req->content_len;
+	int received = 0;
+	int last_pct10 = -1;
+
+	while (remaining > 0) {
+		int to_read = (remaining < OTA_HTTP_CHUNK_SIZE) ? remaining : OTA_HTTP_CHUNK_SIZE;
+		int ret = httpd_req_recv(req, buf, to_read);
+
+		if (ret <= 0) {
+			free(buf);
+			esp_ota_abort(ota_handle);
+			if (ret == HTTPD_SOCK_ERR_TIMEOUT) {
+				httpd_resp_set_status(req, "408 Request Timeout");
+				httpd_resp_sendstr(req, "{\"error\": \"Upload timed out\"}");
+			} else {
+				httpd_resp_set_status(req, "500 Internal Server Error");
+				httpd_resp_sendstr(req, "{\"error\": \"Receive failed\"}");
+			}
+			return ESP_OK;
+		}
+
+		err = esp_ota_write(ota_handle, buf, ret);
+		if (err != ESP_OK) {
+			free(buf);
+			esp_ota_abort(ota_handle);
+			ESP_LOGE(TAG, "%s: esp_ota_write failed: %s", __func__, esp_err_to_name(err));
+			httpd_resp_set_status(req, "500 Internal Server Error");
+			httpd_resp_sendstr(req, "{\"error\": \"OTA write failed\"}");
+			return ESP_OK;
+		}
+
+		received += ret;
+		remaining -= ret;
+
+		int pct10 = received * 10 / req->content_len;
+		if (pct10 != last_pct10) {
+			last_pct10 = pct10;
+			ESP_LOGI(TAG, "%s: OTA progress: %d%%", __func__, pct10 * 10);
+		}
+	}
+
+	free(buf);
+
+	err = esp_ota_end(ota_handle);
+	if (err != ESP_OK) {
+		ESP_LOGE(TAG, "%s: esp_ota_end failed: %s", __func__, esp_err_to_name(err));
+		httpd_resp_set_status(req, "500 Internal Server Error");
+		httpd_resp_sendstr(req, "{\"error\": \"OTA validation failed — invalid firmware?\"}");
+		return ESP_OK;
+	}
+
+	err = esp_ota_set_boot_partition(update_partition);
+	if (err != ESP_OK) {
+		ESP_LOGE(TAG, "%s: esp_ota_set_boot_partition failed: %s", __func__, esp_err_to_name(err));
+		httpd_resp_set_status(req, "500 Internal Server Error");
+		httpd_resp_sendstr(req, "{\"error\": \"Failed to set boot partition\"}");
+		return ESP_OK;
+	}
+
+	ESP_LOGI(TAG, "%s: OTA complete (%d bytes), restarting...", __func__, received);
+
+	httpd_resp_set_status(req, "200 OK");
+	httpd_resp_set_hdr(req, "Connection", "close");
+	httpd_resp_sendstr(req, "{\"success\": true}");
+
+	xTaskCreate(restart_task, "ota_restart", 2048, NULL, 5, NULL);
+
+	return ESP_OK;
+}
+
+/*
+ * GET /api/ota/status
+ * Returns running firmware description so the frontend can confirm a
+ * successful OTA by comparing SHA256 before and after the upload.
+ */
+static esp_err_t get_ota_status_handler(httpd_req_t *req) {
+	ESP_LOGD(TAG, "%s: uri=%s", __func__, req->uri);
+
+	set_cors_headers(req);
+	httpd_resp_set_type(req, "application/json");
+
+	const esp_app_desc_t *desc = esp_app_get_description();
+
+	char sha256[65] = {0};
+	for (int i = 0; i < 32; i++) {
+		snprintf(sha256 + i * 2, 3, "%02x", desc->app_elf_sha256[i]);
+	}
+
+	char json[256];
+	snprintf(json, sizeof(json),
+		"{\"version\":\"%s\",\"project_name\":\"%s\","
+		"\"compile_date\":\"%s\",\"compile_time\":\"%s\","
+		"\"idf_version\":\"%s\",\"sha256\":\"%s\"}",
+		desc->version, desc->project_name,
+		desc->date, desc->time,
+		desc->idf_ver, sha256);
+
+	httpd_resp_sendstr(req, json);
+	return ESP_OK;
+}
+
+void ota_register_handlers(httpd_handle_t server) {
+	httpd_uri_t upload = {
+		.uri     = "/api/ota/upload",
+		.method  = HTTP_POST,
+		.handler = ota_upload_handler,
+	};
+	httpd_register_uri_handler(server, &upload);
+
+	httpd_uri_t upload_options = {
+		.uri     = "/api/ota/upload",
+		.method  = HTTP_OPTIONS,
+		.handler = options_handler,
+	};
+	httpd_register_uri_handler(server, &upload_options);
+
+	httpd_uri_t status = {
+		.uri     = "/api/ota/status",
+		.method  = HTTP_GET,
+		.handler = get_ota_status_handler,
+	};
+	httpd_register_uri_handler(server, &status);
+}
+
+#endif /* CONFIG_SNAPCLIENT_WEB_OTA */

--- a/components/ui_http_server/ui_http_server.c
+++ b/components/ui_http_server/ui_http_server.c
@@ -18,11 +18,19 @@
 #include "esp_http_server.h"
 #include "esp_log.h"
 #include "esp_system.h"
+#if CONFIG_SNAPCLIENT_WEB_OTA
+#include "esp_app_desc.h"
+#include "esp_ota_ops.h"
+#endif
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 #include "freertos/semphr.h"
 #include "freertos/task.h"
 #include "settings_manager.h"
+
+#if CONFIG_SNAPCLIENT_WEB_OTA
+extern void sc_stop_snapclient(void);
+#endif
 
 #if CONFIG_DAC_TAS5805M
 #include "tas5805m_settings.h"
@@ -51,6 +59,10 @@ extern const uint8_t dac_settings_html_start[] asm("_binary_dac_settings_html_st
 extern const uint8_t dac_settings_html_end[] asm("_binary_dac_settings_html_end");
 extern const uint8_t eq_settings_html_start[] asm("_binary_eq_settings_html_start");
 extern const uint8_t eq_settings_html_end[] asm("_binary_eq_settings_html_end");
+#if CONFIG_SNAPCLIENT_WEB_OTA
+extern const uint8_t ota_update_html_start[] asm("_binary_ota_update_html_start");
+extern const uint8_t ota_update_html_end[] asm("_binary_ota_update_html_end");
+#endif
 extern const uint8_t favicon_ico_start[] asm("_binary_favicon_ico_start");
 extern const uint8_t favicon_ico_end[] asm("_binary_favicon_ico_end");
 
@@ -72,6 +84,9 @@ static const embedded_file_t embedded_files[] = {
 	{"/dsp-settings.html", dsp_settings_html_start, dsp_settings_html_end, "text/html; charset=utf-8"},
 	{"/dac-settings.html", dac_settings_html_start, dac_settings_html_end, "text/html; charset=utf-8"},
 	{"/eq-settings.html", eq_settings_html_start, eq_settings_html_end, "text/html; charset=utf-8"},
+#if CONFIG_SNAPCLIENT_WEB_OTA
+	{"/ota-update.html", ota_update_html_start, ota_update_html_end, "text/html; charset=utf-8"},
+#endif
 	{"/favicon.ico", favicon_ico_start, favicon_ico_end, "image/x-icon"},
 };
 
@@ -924,6 +939,158 @@ static esp_err_t post_eq_settings_handler(httpd_req_t *req) {
 #endif
 }
 
+#if CONFIG_SNAPCLIENT_WEB_OTA
+/*
+ * POST /api/ota/upload handler
+ * Receives a raw firmware binary, writes it to the inactive OTA partition,
+ * sets it as the next boot partition, and restarts.
+ */
+#define OTA_HTTP_CHUNK_SIZE 4096
+
+static esp_err_t ota_upload_handler(httpd_req_t *req) {
+	ESP_LOGD(TAG, "%s: uri=%s content_len=%d", __func__, req->uri, req->content_len);
+
+	set_cors_headers(req);
+	httpd_resp_set_type(req, "application/json");
+
+	if (req->content_len == 0) {
+		httpd_resp_set_status(req, "400 Bad Request");
+		httpd_resp_sendstr(req, "{\"error\": \"No firmware data\"}");
+		return ESP_OK;
+	}
+
+	ESP_LOGI(TAG, "%s: OTA upload started, %d bytes", __func__, req->content_len);
+
+	// Signal snapclient to stop before flashing
+	sc_stop_snapclient();
+	vTaskDelay(pdMS_TO_TICKS(500));
+
+	const esp_partition_t *update_partition = esp_ota_get_next_update_partition(NULL);
+	if (!update_partition) {
+		httpd_resp_set_status(req, "500 Internal Server Error");
+		httpd_resp_sendstr(req, "{\"error\": \"No OTA partition available\"}");
+		return ESP_OK;
+	}
+
+	esp_ota_handle_t ota_handle;
+	esp_err_t err = esp_ota_begin(update_partition, req->content_len, &ota_handle);
+	if (err != ESP_OK) {
+		ESP_LOGE(TAG, "%s: esp_ota_begin failed: %s", __func__, esp_err_to_name(err));
+		httpd_resp_set_status(req, "500 Internal Server Error");
+		httpd_resp_sendstr(req, "{\"error\": \"OTA begin failed\"}");
+		return ESP_OK;
+	}
+
+	char *buf = (char *)malloc(OTA_HTTP_CHUNK_SIZE);
+	if (!buf) {
+		esp_ota_abort(ota_handle);
+		httpd_resp_set_status(req, "500 Internal Server Error");
+		httpd_resp_sendstr(req, "{\"error\": \"Memory allocation failed\"}");
+		return ESP_OK;
+	}
+
+	int remaining = req->content_len;
+	int received = 0;
+	int last_pct10 = -1;
+
+	while (remaining > 0) {
+		int to_read = (remaining < OTA_HTTP_CHUNK_SIZE) ? remaining : OTA_HTTP_CHUNK_SIZE;
+		int ret = httpd_req_recv(req, buf, to_read);
+
+		if (ret <= 0) {
+			free(buf);
+			esp_ota_abort(ota_handle);
+			if (ret == HTTPD_SOCK_ERR_TIMEOUT) {
+				httpd_resp_set_status(req, "408 Request Timeout");
+				httpd_resp_sendstr(req, "{\"error\": \"Upload timed out\"}");
+			} else {
+				httpd_resp_set_status(req, "500 Internal Server Error");
+				httpd_resp_sendstr(req, "{\"error\": \"Receive failed\"}");
+			}
+			return ESP_OK;
+		}
+
+		err = esp_ota_write(ota_handle, buf, ret);
+		if (err != ESP_OK) {
+			free(buf);
+			esp_ota_abort(ota_handle);
+			ESP_LOGE(TAG, "%s: esp_ota_write failed: %s", __func__, esp_err_to_name(err));
+			httpd_resp_set_status(req, "500 Internal Server Error");
+			httpd_resp_sendstr(req, "{\"error\": \"OTA write failed\"}");
+			return ESP_OK;
+		}
+
+		received += ret;
+		remaining -= ret;
+
+		int pct10 = received * 10 / req->content_len;
+		if (pct10 != last_pct10) {
+			last_pct10 = pct10;
+			ESP_LOGI(TAG, "%s: OTA progress: %d%%", __func__, pct10 * 10);
+		}
+	}
+
+	free(buf);
+
+	err = esp_ota_end(ota_handle);
+	if (err != ESP_OK) {
+		ESP_LOGE(TAG, "%s: esp_ota_end failed: %s", __func__, esp_err_to_name(err));
+		httpd_resp_set_status(req, "500 Internal Server Error");
+		httpd_resp_sendstr(req, "{\"error\": \"OTA validation failed — invalid firmware?\"}");
+		return ESP_OK;
+	}
+
+	err = esp_ota_set_boot_partition(update_partition);
+	if (err != ESP_OK) {
+		ESP_LOGE(TAG, "%s: esp_ota_set_boot_partition failed: %s", __func__, esp_err_to_name(err));
+		httpd_resp_set_status(req, "500 Internal Server Error");
+		httpd_resp_sendstr(req, "{\"error\": \"Failed to set boot partition\"}");
+		return ESP_OK;
+	}
+
+	ESP_LOGI(TAG, "%s: OTA complete (%d bytes), restarting...", __func__, received);
+
+	httpd_resp_set_status(req, "200 OK");
+	httpd_resp_set_hdr(req, "Connection", "close");
+	httpd_resp_sendstr(req, "{\"success\": true}");
+
+	xTaskCreate(restart_task, "ota_restart", 2048, NULL, 5, NULL);
+
+	return ESP_OK;
+}
+
+/*
+ * GET /api/ota/status handler
+ * Returns running firmware description so the frontend can confirm a
+ * successful OTA by comparing SHA256 before and after the upload.
+ */
+static esp_err_t get_ota_status_handler(httpd_req_t *req) {
+	ESP_LOGD(TAG, "%s: uri=%s", __func__, req->uri);
+
+	set_cors_headers(req);
+	httpd_resp_set_type(req, "application/json");
+
+	const esp_app_desc_t *desc = esp_app_get_description();
+
+	char sha256[65] = {0};
+	for (int i = 0; i < 32; i++) {
+		snprintf(sha256 + i * 2, 3, "%02x", desc->app_elf_sha256[i]);
+	}
+
+	char json[256];
+	snprintf(json, sizeof(json),
+		"{\"version\":\"%s\",\"project_name\":\"%s\","
+		"\"compile_date\":\"%s\",\"compile_time\":\"%s\","
+		"\"idf_version\":\"%s\",\"sha256\":\"%s\"}",
+		desc->version, desc->project_name,
+		desc->date, desc->time,
+		desc->idf_ver, sha256);
+
+	httpd_resp_sendstr(req, json);
+	return ESP_OK;
+}
+#endif /* CONFIG_SNAPCLIENT_WEB_OTA */
+
 /*
  * Static file handler
  * Serves files from embedded flash memory
@@ -1176,6 +1343,30 @@ esp_err_t start_server(const char *base_path, int port) {
 	};
 	httpd_register_uri_handler(server, &_options_eq_schema_handler);
 #endif /* CONFIG_DAC_TAS5805M */
+
+#if CONFIG_SNAPCLIENT_WEB_OTA
+	/* URI handler for OTA firmware upload */
+	httpd_uri_t _ota_upload_handler = {
+		.uri = "/api/ota/upload",
+		.method = HTTP_POST,
+		.handler = ota_upload_handler,
+	};
+	httpd_register_uri_handler(server, &_ota_upload_handler);
+
+	httpd_uri_t _options_ota_upload_handler = {
+		.uri = "/api/ota/upload",
+		.method = HTTP_OPTIONS,
+		.handler = options_handler,
+	};
+	httpd_register_uri_handler(server, &_options_ota_upload_handler);
+
+	httpd_uri_t _get_ota_status_handler = {
+		.uri = "/api/ota/status",
+		.method = HTTP_GET,
+		.handler = get_ota_status_handler,
+	};
+	httpd_register_uri_handler(server, &_get_ota_status_handler);
+#endif /* CONFIG_SNAPCLIENT_WEB_OTA */
 
 	/* URI handler for static files (catch-all, must be last) */
 	httpd_uri_t _static_file_handler = {

--- a/components/ui_http_server/ui_http_server.c
+++ b/components/ui_http_server/ui_http_server.c
@@ -18,19 +18,12 @@
 #include "esp_http_server.h"
 #include "esp_log.h"
 #include "esp_system.h"
-#if CONFIG_SNAPCLIENT_WEB_OTA
-#include "esp_app_desc.h"
-#include "esp_ota_ops.h"
-#endif
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 #include "freertos/semphr.h"
 #include "freertos/task.h"
 #include "settings_manager.h"
-
-#if CONFIG_SNAPCLIENT_WEB_OTA
-extern void sc_stop_snapclient(void);
-#endif
+#include "ota_handlers.h"
 
 #if CONFIG_DAC_TAS5805M
 #include "tas5805m_settings.h"
@@ -939,158 +932,6 @@ static esp_err_t post_eq_settings_handler(httpd_req_t *req) {
 #endif
 }
 
-#if CONFIG_SNAPCLIENT_WEB_OTA
-/*
- * POST /api/ota/upload handler
- * Receives a raw firmware binary, writes it to the inactive OTA partition,
- * sets it as the next boot partition, and restarts.
- */
-#define OTA_HTTP_CHUNK_SIZE 4096
-
-static esp_err_t ota_upload_handler(httpd_req_t *req) {
-	ESP_LOGD(TAG, "%s: uri=%s content_len=%d", __func__, req->uri, req->content_len);
-
-	set_cors_headers(req);
-	httpd_resp_set_type(req, "application/json");
-
-	if (req->content_len == 0) {
-		httpd_resp_set_status(req, "400 Bad Request");
-		httpd_resp_sendstr(req, "{\"error\": \"No firmware data\"}");
-		return ESP_OK;
-	}
-
-	ESP_LOGI(TAG, "%s: OTA upload started, %d bytes", __func__, req->content_len);
-
-	// Signal snapclient to stop before flashing
-	sc_stop_snapclient();
-	vTaskDelay(pdMS_TO_TICKS(500));
-
-	const esp_partition_t *update_partition = esp_ota_get_next_update_partition(NULL);
-	if (!update_partition) {
-		httpd_resp_set_status(req, "500 Internal Server Error");
-		httpd_resp_sendstr(req, "{\"error\": \"No OTA partition available\"}");
-		return ESP_OK;
-	}
-
-	esp_ota_handle_t ota_handle;
-	esp_err_t err = esp_ota_begin(update_partition, req->content_len, &ota_handle);
-	if (err != ESP_OK) {
-		ESP_LOGE(TAG, "%s: esp_ota_begin failed: %s", __func__, esp_err_to_name(err));
-		httpd_resp_set_status(req, "500 Internal Server Error");
-		httpd_resp_sendstr(req, "{\"error\": \"OTA begin failed\"}");
-		return ESP_OK;
-	}
-
-	char *buf = (char *)malloc(OTA_HTTP_CHUNK_SIZE);
-	if (!buf) {
-		esp_ota_abort(ota_handle);
-		httpd_resp_set_status(req, "500 Internal Server Error");
-		httpd_resp_sendstr(req, "{\"error\": \"Memory allocation failed\"}");
-		return ESP_OK;
-	}
-
-	int remaining = req->content_len;
-	int received = 0;
-	int last_pct10 = -1;
-
-	while (remaining > 0) {
-		int to_read = (remaining < OTA_HTTP_CHUNK_SIZE) ? remaining : OTA_HTTP_CHUNK_SIZE;
-		int ret = httpd_req_recv(req, buf, to_read);
-
-		if (ret <= 0) {
-			free(buf);
-			esp_ota_abort(ota_handle);
-			if (ret == HTTPD_SOCK_ERR_TIMEOUT) {
-				httpd_resp_set_status(req, "408 Request Timeout");
-				httpd_resp_sendstr(req, "{\"error\": \"Upload timed out\"}");
-			} else {
-				httpd_resp_set_status(req, "500 Internal Server Error");
-				httpd_resp_sendstr(req, "{\"error\": \"Receive failed\"}");
-			}
-			return ESP_OK;
-		}
-
-		err = esp_ota_write(ota_handle, buf, ret);
-		if (err != ESP_OK) {
-			free(buf);
-			esp_ota_abort(ota_handle);
-			ESP_LOGE(TAG, "%s: esp_ota_write failed: %s", __func__, esp_err_to_name(err));
-			httpd_resp_set_status(req, "500 Internal Server Error");
-			httpd_resp_sendstr(req, "{\"error\": \"OTA write failed\"}");
-			return ESP_OK;
-		}
-
-		received += ret;
-		remaining -= ret;
-
-		int pct10 = received * 10 / req->content_len;
-		if (pct10 != last_pct10) {
-			last_pct10 = pct10;
-			ESP_LOGI(TAG, "%s: OTA progress: %d%%", __func__, pct10 * 10);
-		}
-	}
-
-	free(buf);
-
-	err = esp_ota_end(ota_handle);
-	if (err != ESP_OK) {
-		ESP_LOGE(TAG, "%s: esp_ota_end failed: %s", __func__, esp_err_to_name(err));
-		httpd_resp_set_status(req, "500 Internal Server Error");
-		httpd_resp_sendstr(req, "{\"error\": \"OTA validation failed — invalid firmware?\"}");
-		return ESP_OK;
-	}
-
-	err = esp_ota_set_boot_partition(update_partition);
-	if (err != ESP_OK) {
-		ESP_LOGE(TAG, "%s: esp_ota_set_boot_partition failed: %s", __func__, esp_err_to_name(err));
-		httpd_resp_set_status(req, "500 Internal Server Error");
-		httpd_resp_sendstr(req, "{\"error\": \"Failed to set boot partition\"}");
-		return ESP_OK;
-	}
-
-	ESP_LOGI(TAG, "%s: OTA complete (%d bytes), restarting...", __func__, received);
-
-	httpd_resp_set_status(req, "200 OK");
-	httpd_resp_set_hdr(req, "Connection", "close");
-	httpd_resp_sendstr(req, "{\"success\": true}");
-
-	xTaskCreate(restart_task, "ota_restart", 2048, NULL, 5, NULL);
-
-	return ESP_OK;
-}
-
-/*
- * GET /api/ota/status handler
- * Returns running firmware description so the frontend can confirm a
- * successful OTA by comparing SHA256 before and after the upload.
- */
-static esp_err_t get_ota_status_handler(httpd_req_t *req) {
-	ESP_LOGD(TAG, "%s: uri=%s", __func__, req->uri);
-
-	set_cors_headers(req);
-	httpd_resp_set_type(req, "application/json");
-
-	const esp_app_desc_t *desc = esp_app_get_description();
-
-	char sha256[65] = {0};
-	for (int i = 0; i < 32; i++) {
-		snprintf(sha256 + i * 2, 3, "%02x", desc->app_elf_sha256[i]);
-	}
-
-	char json[256];
-	snprintf(json, sizeof(json),
-		"{\"version\":\"%s\",\"project_name\":\"%s\","
-		"\"compile_date\":\"%s\",\"compile_time\":\"%s\","
-		"\"idf_version\":\"%s\",\"sha256\":\"%s\"}",
-		desc->version, desc->project_name,
-		desc->date, desc->time,
-		desc->idf_ver, sha256);
-
-	httpd_resp_sendstr(req, json);
-	return ESP_OK;
-}
-#endif /* CONFIG_SNAPCLIENT_WEB_OTA */
-
 /*
  * Static file handler
  * Serves files from embedded flash memory
@@ -1345,28 +1186,8 @@ esp_err_t start_server(const char *base_path, int port) {
 #endif /* CONFIG_DAC_TAS5805M */
 
 #if CONFIG_SNAPCLIENT_WEB_OTA
-	/* URI handler for OTA firmware upload */
-	httpd_uri_t _ota_upload_handler = {
-		.uri = "/api/ota/upload",
-		.method = HTTP_POST,
-		.handler = ota_upload_handler,
-	};
-	httpd_register_uri_handler(server, &_ota_upload_handler);
-
-	httpd_uri_t _options_ota_upload_handler = {
-		.uri = "/api/ota/upload",
-		.method = HTTP_OPTIONS,
-		.handler = options_handler,
-	};
-	httpd_register_uri_handler(server, &_options_ota_upload_handler);
-
-	httpd_uri_t _get_ota_status_handler = {
-		.uri = "/api/ota/status",
-		.method = HTTP_GET,
-		.handler = get_ota_status_handler,
-	};
-	httpd_register_uri_handler(server, &_get_ota_status_handler);
-#endif /* CONFIG_SNAPCLIENT_WEB_OTA */
+	ota_register_handlers(server);
+#endif
 
 	/* URI handler for static files (catch-all, must be last) */
 	httpd_uri_t _static_file_handler = {

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -43,6 +43,13 @@ menu "Snapclient Configuration"
 			default 8000
 			help
 				HTTP server port to use.
+
+		config SNAPCLIENT_WEB_OTA
+			bool "Enable OTA firmware upload via web interface"
+			default y
+			help
+				Expose a /api/ota/upload endpoint and an OTA Update tab in the web UI.
+				Disable to reduce firmware size or restrict update access.
 	endmenu
 
 	config USE_SAMPLE_INSERTION


### PR DESCRIPTION
<img width="2056" height="1574" alt="image" src="https://github.com/user-attachments/assets/437cb3a9-2aca-4f3f-aa67-a7769f9ae88e" />

***

Adds an OTA Update tab to the web UI, gated behind CONFIG_SNAPCLIENT_WEB_OTA (default y). Features:

- POST /api/ota/upload: streams the firmware binary to the inactive OTA partition in 4 KB chunks, stops snapclient beforehand, validates with esp_ota_end(), sets the boot partition, and restarts. Sets Connection: close on the response to avoid a spurious httpd recv warning.

- GET /api/ota/status: returns running firmware info (version, project name, build date, IDF version, SHA256) via esp_app_get_description(), so the frontend can confirm the new image booted after restart.

- ota-update.html: side-by-side current/selected firmware cards. The selected .bin is parsed entirely in the browser by scanning for the esp_app_desc magic word (0xABCD5432) and reading the fixed struct layout, giving an immediate preview with SHA256 match/diff indicator before upload. After flashing, polls /api/ota/status until the device responds and confirms the new firmware is running.

- Kconfig: CONFIG_SNAPCLIENT_WEB_OTA bool under "HTTP Server Setting", default y. All C code, route registrations, and embedded file refs are guarded by this flag. The OTA tab is shown/hidden via the existing capabilities mechanism (web_ota_enabled field in /capabilities).